### PR TITLE
Set domain on OAuth1 token

### DIFF
--- a/garth/auth_tokens.py
+++ b/garth/auth_tokens.py
@@ -11,6 +11,7 @@ class OAuth1Token:
     oauth_token_secret: str
     mfa_token: Optional[str] = None
     mfa_expiration_timestamp: Optional[datetime] = None
+    domain: Optional[str] = None
 
 
 @dataclass

--- a/garth/http.py
+++ b/garth/http.py
@@ -201,13 +201,16 @@ class Client:
             oauth1 = OAuth1Token(**json.load(f))
         with open(os.path.join(dir_path, "oauth2_token.json")) as f:
             oauth2 = OAuth2Token(**json.load(f))
-        self.configure(oauth1_token=oauth1, oauth2_token=oauth2)
+        self.configure(
+            oauth1_token=oauth1, oauth2_token=oauth2, domain=oauth1.domain
+        )
 
     def loads(self, s: str):
         oauth1, oauth2 = json.loads(base64.b64decode(s))
         self.configure(
             oauth1_token=OAuth1Token(**oauth1),
             oauth2_token=OAuth2Token(**oauth2),
+            domain=oauth1.get("domain"),
         )
 
 

--- a/garth/sso.py
+++ b/garth/sso.py
@@ -120,7 +120,7 @@ def get_oauth1_token(ticket: str, client: "http.Client") -> OAuth1Token:
     resp.raise_for_status()
     parsed = parse_qs(resp.text)
     token = {k: v[0] for k, v in parsed.items()}
-    return OAuth1Token(**token)  # type: ignore
+    return OAuth1Token(domain=client.domain, **token)  # type: ignore
 
 
 def exchange(oauth1: OAuth1Token, client: "http.Client") -> OAuth2Token:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ def oauth1_token_dict() -> dict:
         oauth_token_secret="49919d7c4c8241ac93fb4345886fbcea",
         mfa_token="ab316f8640f3491f999f3298f3d6f1bb",
         mfa_expiration_timestamp="2023-08-02 05:56:10.000",
+        domain="garmin.com",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def oauth1_token_dict() -> dict:
         oauth_token="7fdff19aa9d64dda83e9d7858473aed1",
         oauth_token_secret="49919d7c4c8241ac93fb4345886fbcea",
         mfa_token="ab316f8640f3491f999f3298f3d6f1bb",
-        mfa_expiration_timestamp="2023-08-02 05:56:10.000",
+        mfa_expiration_timestamp="2024-08-02 05:56:10.000",
         domain="garmin.com",
     )
 


### PR DESCRIPTION
Whatever domain is being used during the original login is the same one that should continue to be used with the OAuth1 token. This change saves the domain on the OAuth1 token to ensure the correct domain is using when loading from a saved token.

This closes #24, which addresses the issue that caused #21.

This change is fully backwards compatible. The domain is only configured if there's one that's saved. If none is saved, the prior behaviors continues.