### PR TITLE
fix put/delete request

### DIFF
--- a/garth/http.py
+++ b/garth/http.py
@@ -116,6 +116,11 @@ class Client:
             if not self.oauth2_token or self.oauth2_token.expired:
                 self.refresh_oauth2()
             headers["Authorization"] = str(self.oauth2_token)
+
+            if method in ["PUT", "DELETE"]:
+                headers["X-Http-Method-Override"] = method
+                method = "POST"
+
         self.last_resp = self.sess.request(
             method,
             url,


### PR DESCRIPTION
This PR fixes _PUT_ and _DELETE_ requests. 
From browser logs those are actually _POST_ requests with method defined in _X-Http-Method-Override header.
