### PR TITLE
Fixing sample code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ garth.configure(proxies={"https": "http://localhost:8888"}, ssl_verify=False)
 
 ```python
 import garth
-from garth import GarthException
+from garth.exc import GarthException
 
 garth.resume("~/.garth")
 try:


### PR DESCRIPTION
The sample code was failing with error `ImportError: cannot import name 'GarthException' from 'garth' (/opt/homebrew/lib/python3.11/site-packages/garth/__init__.py)`.

Fixed the sample code.