### PR TITLE
Add rename function option to return activity ID from uploaded activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ be contained within the resulting dictionary at
 
 > [!NOTE]  
 > Since this process waits for processing on the Garmin Connect server, be aware that
-> that it can make the upload process can take up to a few seconds longer than usual.
+> it can make the upload process can take up to a few seconds longer than usual.
 
 ```python
 with open("12129115726_ACTIVITY.fit", "rb") as f:

--- a/garth/http.py
+++ b/garth/http.py
@@ -193,6 +193,12 @@ class Client:
     ) -> Dict[str, Any]:
         """Upload FIT file to Garmin Connect.
 
+        If ``return_id`` is true, the upload function will perform a retry loop
+        (up to five times) to poll if Garmin Connect has finished assigning an
+        ID number to the activity. This can add up to 7.5 seconds of waiting
+        for the request to finish (though typically it takes about 1.5
+        seconds).
+
         Args:
             fp: open file pointer to FIT file
             path: the API endpoint to use
@@ -218,7 +224,6 @@ class Client:
             files=files,
         )
         result = None if resp.status_code == 204 else resp.json()
-        assert result is not None, "No result from upload"
         if result is None:
             raise GarthHTTPError(
                 msg=(


### PR DESCRIPTION
Resolves #88.

Not much to describe apart from the PR title.

I modified `upload()` to use `Client.request` to be able to access the "location" response header, which contains the URL needed to fetch the activity ID of the uploaded file. This is not returned initially when the file is uploaded, as it takes Garmin some time to process the activity. I implemented a simple polling process to check if the ID is ready, backing off by half a second with each try. If it doesn't return the value within 5 tries, it gives up.

The headers include with the `rename()` implementation are what I found to be the minimum required, but I'm not very experienced with the Garmin API, so maybe you have a better implementation.

I also edited the readme to describe the new functionality with a demo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ability to retrieve Garmin Connect activity ID after uploading an activity.
  - Introduced method to rename activities on Garmin Connect.
- **Documentation**
  - Updated README with new upload method usage and example code.
- **Improvements**
  - Enhanced upload method with optional ID retrieval.
  - Implemented retry mechanism for fetching activity ID.
  - Noted potential delay in upload process due to server response time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->