### PR TITLE
Change `profile_image_uuid` to `profile_image_type`

### DIFF
--- a/garth/users/profile.py
+++ b/garth/users/profile.py
@@ -14,7 +14,7 @@ class UserProfile:
     display_name: str
     full_name: str
     user_name: str
-    profile_image_uuid: str | None
+    profile_image_type: str | None
     profile_image_url_large: str | None
     profile_image_url_medium: str | None
     profile_image_url_small: str | None

--- a/tests/cassettes/test_user_profile.yaml
+++ b/tests/cassettes/test_user_profile.yaml
@@ -21,7 +21,7 @@ interactions:
     body:
       string: '{"id": 3154645, "profileId": 2591602, "garminGUID": "0690cc1d-d23d-4412-b027-80fd4ed1c0f6",
         "displayName": "mtamizi", "fullName": "Matin Tamizi", "userName": "mtamizi",
-        "profileImageUuid": "73240e81-6e4d-43fc-8af8-c8f6c51b3b8f", "profileImageUrlLarge":
+        "profileImageType": "73240e81-6e4d-43fc-8af8-c8f6c51b3b8f", "profileImageUrlLarge":
         "https://s3.amazonaws.com/garmin-connect-prod/profile_images/73240e81-6e4d-43fc-8af8-c8f6c51b3b8f-2591602.png",
         "profileImageUrlMedium": "https://s3.amazonaws.com/garmin-connect-prod/profile_images/685a19e9-a7be-4a11-9bf9-faca0c5d1f1a-2591602.png",
         "profileImageUrlSmall": "https://s3.amazonaws.com/garmin-connect-prod/profile_images/6302f021-0ec7-4dc9-b0c3-d5a19bc5a08c-2591602.png",


### PR DESCRIPTION
I reported this problem in #96 , and here is the fix that I got working. This should fix uses of `garth.UserProfile.get()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the way profile image details are represented on user profiles, ensuring a more descriptive and consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->