### PR TITLE
define ci permissions to address cwe275

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ on:
 env:
   COLUMNS: 150
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+  statuses: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow configuration to clarify and explicitly define permissions used by the automated checks. No changes to the build or test processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->