### PR TITLE
Add additional metrics - Hill + Endurance score, Morning Training Readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,79 @@ garth.WeightData.list("2025-06-01", 30)
 ]
 ```
 
+### Additional Garmin Scores
+
+Retrieve additional Garmin Scores for a given date.
+
+```python
+garth.GarminScoresData.get("2025-07-07")
+```
+
+```python
+GarminScoresData(
+    user_profile_pk=131234790,
+    calendar_date=datetime.date(2025, 7, 7),
+    endurance_score=4820,
+    endurance_classification=1,
+    endurance_classification_lower_limit_elite=8800,
+    endurance_classification_lower_limit_superior=8100,
+    endurance_classification_lower_limit_expert=7300,
+    endurance_classification_lower_limit_well_trained=6600,
+    endurance_classification_lower_limit_trained=5800,
+    endurance_classification_lower_limit_intermediate=5100,
+    hill_score=20,
+    hill_endurance_score=15,
+    hill_strength_score=2,
+    vo_2_max=48.0,
+    vo_2_max_precise_value=48.0
+)
+```
+
+Retrieve additional Garmin Scores for a list of dates.
+
+```python
+garth.GarminScoresData.list("2025-07-07", 2)
+```
+
+```python
+[
+    GarminScoresData(
+        user_profile_pk=131234790,
+        calendar_date=datetime.date(2025, 7, 6),
+        endurance_score=4820,
+        endurance_classification=1,
+        endurance_classification_lower_limit_elite=8800,
+        endurance_classification_lower_limit_superior=8100,
+        endurance_classification_lower_limit_expert=7300,
+        endurance_classification_lower_limit_well_trained=6600,
+        endurance_classification_lower_limit_trained=5800,
+        endurance_classification_lower_limit_intermediate=5100,
+        hill_score=20,
+        hill_endurance_score=15,
+        hill_strength_score=2,
+        vo_2_max=48.0,
+        vo_2_max_precise_value=48.0
+    ),
+    GarminScoresData(
+        user_profile_pk=131234790,
+        calendar_date=datetime.date(2025, 7, 7),
+        endurance_score=4820,
+        endurance_classification=1,
+        endurance_classification_lower_limit_elite=8800,
+        endurance_classification_lower_limit_superior=8100,
+        endurance_classification_lower_limit_expert=7300,
+        endurance_classification_lower_limit_well_trained=6600,
+        endurance_classification_lower_limit_trained=5800,
+        endurance_classification_lower_limit_intermediate=5100,
+        hill_score=20,
+        hill_endurance_score=15,
+        hill_strength_score=2,
+        vo_2_max=48.0,
+        vo_2_max_precise_value=48.0
+    )
+]
+```
+
 ## User
 
 ### UserProfile

--- a/README.md
+++ b/README.md
@@ -978,6 +978,94 @@ garth.GarminScoresData.list("2025-07-07", 2)
 ]
 ```
 
+### Morning Training Readiness
+
+Retrieve the Morning Training Readiness evaluation for a given date.
+
+```python
+garth.MorningTrainingReadinessData.get("2025-07-07")
+```
+
+```python
+MorningTrainingReadinessData(
+    user_profile_pk=131234790,
+    calendar_date=datetime.date(2025, 7, 7),
+    score=100,
+    recovery_time=1.0,
+    recovery_time_factor_feedback='GOOD',
+    recovery_time_factor_percent=99,
+    acute_load=20,
+    hrv_factor_feedback='GOOD',
+    hrv_factor_percent=92,
+    hrv_weekly_average=53,
+    sleep_history_factor_feedback='VERY_GOOD',
+    sleep_history_factor_percent=92,
+    sleep_score=80,
+    sleep_score_factor_feedback='GOOD',
+    sleep_score_factor_percent=70,
+    stress_history_factor_feedback='GOOD',
+    stress_history_factor_percent=72,
+    feedback_short='READY_FOR_ACTION',
+    timestamp=datetime.datetime(2025, 7, 7, 4, 0, 25),
+    timestamp_local=datetime.datetime(2025, 7, 7, 6, 0, 25)
+)
+```
+
+Retrieve Morning Training Readiness for a list of dates.
+
+```python
+garth.MorningTrainingReadinessData.list("2025-07-07", 2)
+```
+
+```python
+[
+    MorningTrainingReadinessData(
+        user_profile_pk=131234790,
+        calendar_date=datetime.date(2025, 7, 6),
+        score=100,
+        recovery_time=0.0,
+        recovery_time_factor_feedback='VERY_GOOD',
+        recovery_time_factor_percent=100,
+        acute_load=24,
+        hrv_factor_feedback='GOOD',
+        hrv_factor_percent=89,
+        hrv_weekly_average=53,
+        sleep_history_factor_feedback='VERY_GOOD',
+        sleep_history_factor_percent=92,
+        sleep_score=91,
+        sleep_score_factor_feedback='VERY_GOOD',
+        sleep_score_factor_percent=91,
+        stress_history_factor_feedback='GOOD',
+        stress_history_factor_percent=79,
+        feedback_short='READY_FOR_ACTION',
+        timestamp=datetime.datetime(2025, 7, 6, 5, 59, 18),
+        timestamp_local=datetime.datetime(2025, 7, 6, 7, 59, 18)
+    ),
+    MorningTrainingReadinessData(
+        user_profile_pk=131234790,
+        calendar_date=datetime.date(2025, 7, 7),
+        score=100,
+        recovery_time=1.0,
+        recovery_time_factor_feedback='GOOD',
+        recovery_time_factor_percent=99,
+        acute_load=20,
+        hrv_factor_feedback='GOOD',
+        hrv_factor_percent=92,
+        hrv_weekly_average=53,
+        sleep_history_factor_feedback='VERY_GOOD',
+        sleep_history_factor_percent=92,
+        sleep_score=80,
+        sleep_score_factor_feedback='GOOD',
+        sleep_score_factor_percent=70,
+        stress_history_factor_feedback='GOOD',
+        stress_history_factor_percent=72,
+        feedback_short='READY_FOR_ACTION',
+        timestamp=datetime.datetime(2025, 7, 7, 4, 0, 25),
+        timestamp_local=datetime.datetime(2025, 7, 7, 6, 0, 25)
+    )
+]
+```
+
 ## User
 
 ### UserProfile

--- a/src/garth/__init__.py
+++ b/src/garth/__init__.py
@@ -3,6 +3,7 @@ from .data import (
     DailyBodyBatteryStress,
     GarminScoresData,
     HRVData,
+    MorningTrainingReadinessData,
     SleepData,
     WeightData,
 )
@@ -34,6 +35,7 @@ __all__ = [
     "DailyStress",
     "GarminScoresData",
     "HRVData",
+    "MorningTrainingReadinessData",
     "SleepData",
     "WeightData",
     "UserProfile",

--- a/src/garth/__init__.py
+++ b/src/garth/__init__.py
@@ -1,6 +1,7 @@
 from .data import (
     BodyBatteryData,
     DailyBodyBatteryStress,
+    GarminScoresData,
     HRVData,
     SleepData,
     WeightData,
@@ -31,6 +32,7 @@ __all__ = [
     "DailySleep",
     "DailySteps",
     "DailyStress",
+    "GarminScoresData",
     "HRVData",
     "SleepData",
     "WeightData",

--- a/src/garth/data/__init__.py
+++ b/src/garth/data/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "DailyBodyBatteryStress",
     "GarminScoresData",
     "HRVData",
+    "MorningTrainingReadinessData",
     "SleepData",
     "StressReading",
     "WeightData",
@@ -19,5 +20,6 @@ from .body_battery import (
 )
 from .garmin_scores import GarminScoresData
 from .hrv import HRVData
+from .morning_training_readiness import MorningTrainingReadinessData
 from .sleep import SleepData
 from .weight import WeightData

--- a/src/garth/data/__init__.py
+++ b/src/garth/data/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     "BodyBatteryEvent",
     "BodyBatteryReading",
     "DailyBodyBatteryStress",
+    "GarminScoresData",
     "HRVData",
     "SleepData",
     "StressReading",
@@ -16,6 +17,7 @@ from .body_battery import (
     DailyBodyBatteryStress,
     StressReading,
 )
+from .garmin_scores import GarminScoresData
 from .hrv import HRVData
 from .sleep import SleepData
 from .weight import WeightData

--- a/src/garth/data/garmin_scores.py
+++ b/src/garth/data/garmin_scores.py
@@ -1,0 +1,74 @@
+from datetime import date
+
+from pydantic.dataclasses import dataclass
+from typing_extensions import Self
+
+from .. import http
+from ..utils import (
+    camel_to_snake_dict,
+)
+from ._base import Data
+
+
+@dataclass
+class GarminScoresData(Data):
+    user_profile_pk: int
+    calendar_date: date
+    endurance_score: int
+    endurance_classification: int
+    endurance_classification_lower_limit_elite: int
+    endurance_classification_lower_limit_superior: int
+    endurance_classification_lower_limit_expert: int
+    endurance_classification_lower_limit_well_trained: int
+    endurance_classification_lower_limit_trained: int
+    endurance_classification_lower_limit_intermediate: int
+    hill_score: int
+    hill_endurance_score: int
+    hill_strength_score: int
+    vo_2_max: float
+    vo_2_max_precise_value: float
+
+    @classmethod
+    def get(
+        cls, day: date | str, *, client: http.Client | None = None
+    ) -> Self | None:
+        client = client or http.client
+        path_hill_score = "/metrics-service/metrics/hillscore"
+        path_endurance_score = "/metrics-service/metrics/endurancescore"
+        data_hill_score = client.connectapi(
+            path_hill_score, params={"calendarDate": day}
+        )
+        data_endurance_score = client.connectapi(
+            path_endurance_score, params={"calendarDate": day}
+        )
+
+        if not data_hill_score or not data_endurance_score:
+            return None
+
+        data_hill_score = camel_to_snake_dict(data_hill_score)
+        data_endurance_score = camel_to_snake_dict(data_endurance_score)
+        data_hill_score["hill_score"] = data_hill_score.pop("overall_score")
+        data_hill_score["hill_endurance_score"] = data_hill_score.pop(
+            "endurance_score"
+        )
+        data_hill_score["hill_strength_score"] = data_hill_score.pop(
+            "strength_score"
+        )
+        data_endurance_score["endurance_score"] = data_endurance_score.pop(
+            "overall_score"
+        )
+        data_endurance_score = {
+            ("endurance_classification" + key[len("classification") :])
+            if key.startswith("classification")
+            else key: value
+            for key, value in data_endurance_score.items()
+        }
+
+        data = {**data_hill_score, **data_endurance_score}
+
+        return cls(**data)
+
+    @classmethod
+    def list(cls, *args, **kwargs) -> list[Self]:
+        data = super().list(*args, **kwargs)
+        return sorted(data, key=lambda d: d.calendar_date)

--- a/src/garth/data/morning_training_readiness.py
+++ b/src/garth/data/morning_training_readiness.py
@@ -1,0 +1,69 @@
+from datetime import date, datetime
+from typing import Any, cast
+
+from pydantic.dataclasses import dataclass
+from typing_extensions import Self
+
+from .. import http
+from ..utils import (
+    camel_to_snake_dict,
+)
+from ._base import Data
+
+
+@dataclass
+class MorningTrainingReadinessData(Data):
+    user_profile_pk: int
+    calendar_date: date
+    score: int
+    recovery_time: float
+    recovery_time_factor_feedback: str
+    recovery_time_factor_percent: int
+    acute_load: int
+    hrv_factor_feedback: str
+    hrv_factor_percent: int
+    hrv_weekly_average: int
+    sleep_history_factor_feedback: str
+    sleep_history_factor_percent: int
+    sleep_score: int
+    sleep_score_factor_feedback: str
+    sleep_score_factor_percent: int
+    stress_history_factor_feedback: str
+    stress_history_factor_percent: int
+    feedback_short: str
+    timestamp: datetime
+    timestamp_local: datetime
+
+    @classmethod
+    def get(
+        cls, day: date | str, *, client: http.Client | None = None
+    ) -> Self | None:
+        client = client or http.client
+        path = f"/metrics-service/metrics/trainingreadiness/{day}"
+        raw_data = client.connectapi(path)
+
+        if not raw_data:
+            return None
+
+        data = cast(list[dict[str, Any]], raw_data)
+
+        # Extract only the part with morning readiness
+        morning_readiness_data = next(
+            (
+                entry
+                for entry in data
+                if entry["inputContext"] == "AFTER_WAKEUP_RESET"
+            ),
+            None,
+        )
+
+        if not morning_readiness_data:
+            return None
+
+        morning_readiness_data = camel_to_snake_dict(morning_readiness_data)
+        return cls(**morning_readiness_data)
+
+    @classmethod
+    def list(cls, *args, **kwargs) -> list[Self]:
+        data = super().list(*args, **kwargs)
+        return sorted(data, key=lambda d: d.calendar_date)

--- a/tests/data/cassettes/test_garmin_scores_data_get.yaml
+++ b/tests/data/cassettes/test_garmin_scores_data_get.yaml
@@ -1,0 +1,296 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.4
+    method: GET
+    uri: https://thegarth.s3.amazonaws.com/oauth_consumer.json
+  response:
+    body:
+      string: '{"consumer_key": "SANITIZED", "consumer_secret": "SANITIZED"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '124'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 09 Jul 2025 19:27:47 GMT
+      ETag:
+      - '"20240b1013cb35419bb5b2cff1407a4e"'
+      Last-Modified:
+      - Thu, 03 Aug 2023 00:16:11 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - QVFDUnhgKpDHuPGkUK0v+VNiTYtqI0ekOSFgadoklEs/1Fyc0WFGR2iT5SqrxyMGLuhG3Qlb1Ro=
+      x-amz-request-id:
+      - QKJV1KSNAGJW1RP7
+      x-amz-server-side-encryption:
+      - AES256
+    status:
+      code: 200
+      message: OK
+- request:
+    body: mfa_token=SANITIZED
+    headers:
+      Accept:
+        SANITIZED
+      Accept-Encoding:
+        SANITIZED
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+        SANITIZED
+      Content-Length:
+      - '74'
+      Content-Type:
+        SANITIZED
+      User-Agent:
+        SANITIZED
+    method: POST
+    uri: https://connectapi.garmin.com/oauth-service/oauth/exchange/user/2.0
+  response:
+    body:
+      string: '{"scope": "COMMUNITY_COURSE_READ GARMINPAY_WRITE GOLF_API_READ ATP_READ
+        GHS_SAMD GHS_UPLOAD INSIGHTS_READ DIVE_API_READ COMMUNITY_COURSE_WRITE CONNECT_WRITE
+        GCOFFER_WRITE DI_OAUTH_2_AUTHORIZATION_CODE_CREATE GARMINPAY_READ DT_CLIENT_ANALYTICS_WRITE
+        GOLF_API_WRITE INSIGHTS_WRITE PRODUCT_SEARCH_READ OMT_CAMPAIGN_READ OMT_SUBSCRIPTION_READ
+        GCOFFER_READ CONNECT_READ ATP_WRITE", "jti": "SANITIZED", "access_token":
+        "SANITIZED", "token_type": "bearer", "refresh_token": "SANITIZED", "expires_in":
+        80337, "refresh_token_expires_in": 2591999}'
+    headers:
+      CF-RAY:
+      - 95ca387e9e24ae1d-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 09 Jul 2025 19:27:47 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=1tmh4uIGSf6YyhYkZM3K8UZ0zLwYjCMnwmSLsIyskyw9H%2BPWJkulc9%2FIxw%2F2hK6PLNQ4aWuVJy%2F7f9C%2BA68Cr2KtcG844TJnZG5YS6lOcCWAn%2F09%2BVzsg5NOe89u%2FkuNwlNYK1eCNw%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - _cfuvid=SANITIZED; path=SANITIZED; domain=SANITIZED; HttpOnly; Secure; SameSite=SANITIZED
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - GCM-iOS-5.7.2.1
+    method: GET
+    uri: https://connectapi.garmin.com/metrics-service/metrics/hillscore?calendarDate=2025-07-07
+  response:
+    body:
+      string: '{"userProfilePK": 131234790, "deviceId": 3477316333, "calendarDate":
+        "2025-07-07", "strengthScore": 2, "enduranceScore": 15, "hillScoreClassificationId":
+        1, "overallScore": 20, "hillScoreFeedbackPhraseId": 4, "vo2Max": 48.0, "vo2MaxPreciseValue":
+        48.0, "primaryTrainingDevice": true}'
+    headers:
+      CF-RAY:
+      - 95ca38849951deac-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 09 Jul 2025 19:27:48 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=4VBTEfgx%2BEG4bdToqG57%2BO3p7TbQwLfg8g41nrH6l3L7x8SXYBW3G6KGJzegX3QONsOvgO6McPZcxKSUFYQmWfTVUaO%2FQgu2speZM2nNIbspqtOhQAl9LUtRE2rA%2BC0I4v%2F1vMWomA%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - _cfuvid=SANITIZED; path=SANITIZED; domain=SANITIZED; HttpOnly; Secure; SameSite=SANITIZED
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+      - keep-alive
+      Cookie:
+      - _cfuvid=SANITIZED
+      User-Agent:
+      - GCM-iOS-5.7.2.1
+    method: GET
+    uri: https://connectapi.garmin.com/metrics-service/metrics/endurancescore?calendarDate=2025-07-07
+  response:
+    body:
+      string: '{"userProfilePK": 131234790, "deviceId": 3477316333, "calendarDate":
+        "2025-07-07", "overallScore": 4820, "classification": 1, "feedbackPhrase":
+        30, "primaryTrainingDevice": true, "gaugeLowerLimit": 3570, "classificationLowerLimitIntermediate":
+        5100, "classificationLowerLimitTrained": 5800, "classificationLowerLimitWellTrained":
+        6600, "classificationLowerLimitExpert": 7300, "classificationLowerLimitSuperior":
+        8100, "classificationLowerLimitElite": 8800, "gaugeUpperLimit": 10560, "contributors":
+        [{"activityTypeId": 9, "group": null, "contribution": 43.02}, {"activityTypeId":
+        null, "group": 0, "contribution": 26.68}, {"activityTypeId": 3, "group": null,
+        "contribution": 23.8}, {"activityTypeId": null, "group": 8, "contribution":
+        6.5}]}'
+    headers:
+      CF-RAY:
+      - 95ca38870b51f980-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 09 Jul 2025 19:27:48 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=ygxWYPFI%2FEhfZkO%2BY1ZsxEY0G29KRv7rVGBZBjsOzTXi96ygG1H2xMMKZSR6VEWxRFqEqMh5ba3dDludxprm%2B946DOIlXBvNCisV6pQJGBpAqO5SyFFA%2F05kspQTtPqxiU5YtcHk8A%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+      - keep-alive
+      Cookie:
+      - _cfuvid=SANITIZED
+      User-Agent:
+      - GCM-iOS-5.7.2.1
+    method: GET
+    uri: https://connectapi.garmin.com/metrics-service/metrics/hillscore?calendarDate=2024-07-07
+  response:
+    body:
+      string: ''
+    headers:
+      CF-RAY:
+      - 95ca3888eebe55c4-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 09 Jul 2025 19:27:48 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=Jwuk0fj8CCNsh2b9LhaO%2FJcXbFctxBFCCAB70XuYDoraR%2B3NEowiPF8kguVQEZfQc1tJz%2BhJY9FdAXimgDFZ3XJetxIkW6JR%2FBX8cHh4mYf7m%2FkBubX4gObLx8ImUHJ%2BzB%2FqfH%2F7KQ%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+      - keep-alive
+      Cookie:
+      - _cfuvid=SANITIZED
+      User-Agent:
+      - GCM-iOS-5.7.2.1
+    method: GET
+    uri: https://connectapi.garmin.com/metrics-service/metrics/endurancescore?calendarDate=2024-07-07
+  response:
+    body:
+      string: ''
+    headers:
+      CF-RAY:
+      - 95ca388b7db5f96e-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 09 Jul 2025 19:27:49 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=3eQRqRWO6eNs%2FCfeQ4HlowHhgesqtaI4nqsfBX%2B9KeUrxsHS7r%2BOy93I9ruZHNjKaA5PXWKYVPMmsowSbm4dgz%2FZNazrtuLJjAfgYB3X1oL19TX2WOgtWpAbswcYvx0YW9zU56EETg%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/data/cassettes/test_garmin_scores_data_list.yaml
+++ b/tests/data/cassettes/test_garmin_scores_data_list.yaml
@@ -1,0 +1,218 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - GCM-iOS-5.7.2.1
+    method: GET
+    uri: https://connectapi.garmin.com/metrics-service/metrics/hillscore?calendarDate=2025-07-07
+  response:
+    body:
+      string: '{"userProfilePK": 131234790, "deviceId": 3345342345, "calendarDate":
+        "2025-07-07", "strengthScore": 2, "enduranceScore": 15, "hillScoreClassificationId":
+        1, "overallScore": 20, "hillScoreFeedbackPhraseId": 4, "vo2Max": 48.0, "vo2MaxPreciseValue":
+        48.0, "primaryTrainingDevice": true}'
+    headers:
+      CF-RAY:
+      - 95d8ecf20c2e87f2-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 11 Jul 2025 14:17:39 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=YnQKbN9WmYtbC3r6NUY9EtTgoUdZB38k4hwvWmfnibXcoznIJRphqH2uuNnGyc9SIEjYxZPJQ9Ljq0b2YMeGXKzA%2FlnKywPKlCeiQKgkNSRSwEtYDh6ZAnlKHNIECIaumQOZkXxy5g%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - _cfuvid=SANITIZED; path=SANITIZED; domain=SANITIZED; HttpOnly; Secure; SameSite=SANITIZED
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+      - keep-alive
+      Cookie:
+      - _cfuvid=SANITIZED
+      User-Agent:
+      - GCM-iOS-5.7.2.1
+    method: GET
+    uri: https://connectapi.garmin.com/metrics-service/metrics/endurancescore?calendarDate=2025-07-07
+  response:
+    body:
+      string: '{"userProfilePK": 131234790, "deviceId": 3345342345, "calendarDate":
+        "2025-07-07", "overallScore": 4820, "classification": 1, "feedbackPhrase":
+        30, "primaryTrainingDevice": true, "gaugeLowerLimit": 3570, "classificationLowerLimitIntermediate":
+        5100, "classificationLowerLimitTrained": 5800, "classificationLowerLimitWellTrained":
+        6600, "classificationLowerLimitExpert": 7300, "classificationLowerLimitSuperior":
+        8100, "classificationLowerLimitElite": 8800, "gaugeUpperLimit": 10560, "contributors":
+        [{"activityTypeId": 9, "group": null, "contribution": 43.02}, {"activityTypeId":
+        null, "group": 0, "contribution": 26.68}, {"activityTypeId": 3, "group": null,
+        "contribution": 23.8}, {"activityTypeId": null, "group": 8, "contribution":
+        6.5}]}'
+    headers:
+      CF-RAY:
+      - 95d8ecf38d8c6e9a-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 11 Jul 2025 14:17:39 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=eFcXSVvPArNQOdtxkc1SrNfrZWCGQ1qIUK4pqvx%2FaMF2jOlJidbOCGgahNooZ0x2bWijG1xOzQ%2BUwIFmunLbYKo2lk98qO1IHRxntxtrNSoKCpyQvBoVLQYNTDrsNlPDA%2F8K%2FhSffg%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+      - keep-alive
+      Cookie:
+      - _cfuvid=SANITIZED
+      User-Agent:
+      - GCM-iOS-5.7.2.1
+    method: GET
+    uri: https://connectapi.garmin.com/metrics-service/metrics/hillscore?calendarDate=2025-07-06
+  response:
+    body:
+      string: '{"userProfilePK": 131234790, "deviceId": 3345342345, "calendarDate":
+        "2025-07-06", "strengthScore": 2, "enduranceScore": 15, "hillScoreClassificationId":
+        1, "overallScore": 20, "hillScoreFeedbackPhraseId": 44, "vo2Max": 48.0, "vo2MaxPreciseValue":
+        48.0, "primaryTrainingDevice": true}'
+    headers:
+      CF-RAY:
+      - 95d8ecf5081236f5-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 11 Jul 2025 14:17:39 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=zmLaM9NZTMvpMEJbNBisfOCe%2B8gDnpZNRNdTc1fPiZTj8521F8mQWVIzhozCVMNtA8xp7GXStcq5DryAa7wmnuKAJXAWwaZ63%2FooYRdDhT8lJMXxn87A8aB9DJteFgjkMlWZE1rtvg%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+      - keep-alive
+      Cookie:
+      - _cfuvid=SANITIZED
+      User-Agent:
+      - GCM-iOS-5.7.2.1
+    method: GET
+    uri: https://connectapi.garmin.com/metrics-service/metrics/endurancescore?calendarDate=2025-07-06
+  response:
+    body:
+      string: '{"userProfilePK": 131234790, "deviceId": 3345342345, "calendarDate":
+        "2025-07-06", "overallScore": 4820, "classification": 1, "feedbackPhrase":
+        30, "primaryTrainingDevice": true, "gaugeLowerLimit": 3570, "classificationLowerLimitIntermediate":
+        5100, "classificationLowerLimitTrained": 5800, "classificationLowerLimitWellTrained":
+        6600, "classificationLowerLimitExpert": 7300, "classificationLowerLimitSuperior":
+        8100, "classificationLowerLimitElite": 8800, "gaugeUpperLimit": 10560, "contributors":
+        [{"activityTypeId": 9, "group": null, "contribution": 43.02}, {"activityTypeId":
+        null, "group": 0, "contribution": 26.68}, {"activityTypeId": 3, "group": null,
+        "contribution": 23.8}, {"activityTypeId": null, "group": 8, "contribution":
+        6.5}]}'
+    headers:
+      CF-RAY:
+      - 95d8ecf719b62759-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 11 Jul 2025 14:17:39 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=5W7%2FRBAizPeLXbxNInT98%2FuCz4zr7XRqqsql9GNDtH6BBr5AG5IcQd715o2Ud0N%2FAJNW9hhGDPDfQFwy10mES0oT0yXWOqz4ju9aBxpPZ17dUm9uT73R04sS8gj%2Bp2r%2BetUs5wV92Q%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/data/cassettes/test_morning_training_readiness_data_get.yaml
+++ b/tests/data/cassettes/test_morning_training_readiness_data_get.yaml
@@ -1,0 +1,188 @@
+interactions:
+- request:
+    body: mfa_token=SANITIZED
+    headers:
+      Accept:
+        SANITIZED
+      Accept-Encoding:
+        SANITIZED
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+        SANITIZED
+      Content-Length:
+      - '74'
+      Content-Type:
+        SANITIZED
+      User-Agent:
+        SANITIZED
+    method: POST
+    uri: https://connectapi.garmin.com/oauth-service/oauth/exchange/user/2.0
+  response:
+    body:
+      string: '{"scope": "COMMUNITY_COURSE_READ GARMINPAY_WRITE GOLF_API_READ ATP_READ
+        GHS_SAMD GHS_UPLOAD INSIGHTS_READ DIVE_API_READ COMMUNITY_COURSE_WRITE CONNECT_WRITE
+        GCOFFER_WRITE DI_OAUTH_2_AUTHORIZATION_CODE_CREATE GARMINPAY_READ DT_CLIENT_ANALYTICS_WRITE
+        GOLF_API_WRITE INSIGHTS_WRITE PRODUCT_SEARCH_READ OMT_CAMPAIGN_READ OMT_SUBSCRIPTION_READ
+        GCOFFER_READ CONNECT_READ ATP_WRITE", "jti": "SANITIZED", "access_token":
+        "SANITIZED", "token_type": "bearer", "refresh_token": "SANITIZED", "expires_in":
+        92485, "refresh_token_expires_in": 2591999}'
+    headers:
+      CF-RAY:
+      - 95ca388d9f20b38b-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 09 Jul 2025 19:27:50 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=6LN7EEa4Cz1%2BqVVODej2nD1Ydhi8pOPc7boWcCvIq0dJqBNY6mvZrlRT9%2BMSLMq86WBvFtDWJ%2FBC8CmBa037DhFgvv4%2BjDm4Z5dh6Fu6unhK9q4THs6ydjVKgUpl5OT%2FnOQwKeXAnw%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - _cfuvid=SANITIZED; path=SANITIZED; domain=SANITIZED; HttpOnly; Secure; SameSite=SANITIZED
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - GCM-iOS-5.7.2.1
+    method: GET
+    uri: https://connectapi.garmin.com/metrics-service/metrics/trainingreadiness/2025-07-07
+  response:
+    body:
+      string: '[{"userProfilePK": 131234790, "calendarDate": "2025-07-07", "timestamp":
+        "2025-07-07T17:43:54.0", "timestampLocal": "2025-07-07T19:43:54.0", "deviceId":
+        3477316333, "level": "PRIME", "feedbackLong": "PRIME_RT_HIGHEST_SS_AVAILABLE_ACWR_POS",
+        "feedbackShort": "READY_FOR_ACTION", "score": 100, "sleepScore": 80, "sleepScoreFactorPercent":
+        70, "sleepScoreFactorFeedback": "GOOD", "recoveryTime": 1, "recoveryTimeFactorPercent":
+        99, "recoveryTimeFactorFeedback": "GOOD", "acwrFactorPercent": 100, "acwrFactorFeedback":
+        "VERY_GOOD", "acuteLoad": 20, "stressHistoryFactorPercent": 72, "stressHistoryFactorFeedback":
+        "GOOD", "hrvFactorPercent": 92, "hrvFactorFeedback": "GOOD", "hrvWeeklyAverage":
+        53, "sleepHistoryFactorPercent": 92, "sleepHistoryFactorFeedback": "VERY_GOOD",
+        "validSleep": true, "inputContext": "AFTER_POST_EXERCISE_RESET", "primaryActivityTracker":
+        true, "recoveryTimeChangePhrase": "REACHED_ZERO"}, {"userProfilePK": 131234790,
+        "calendarDate": "2025-07-07", "timestamp": "2025-07-07T04:00:25.0", "timestampLocal":
+        "2025-07-07T06:00:25.0", "deviceId": 3477316333, "level": "PRIME", "feedbackLong":
+        "PRIME_RT_HIGHEST_SS_AVAILABLE_ACWR_POS", "feedbackShort": "READY_FOR_ACTION",
+        "score": 100, "sleepScore": 80, "sleepScoreFactorPercent": 70, "sleepScoreFactorFeedback":
+        "GOOD", "recoveryTime": 1, "recoveryTimeFactorPercent": 99, "recoveryTimeFactorFeedback":
+        "GOOD", "acwrFactorPercent": 100, "acwrFactorFeedback": "VERY_GOOD", "acuteLoad":
+        20, "stressHistoryFactorPercent": 72, "stressHistoryFactorFeedback": "GOOD",
+        "hrvFactorPercent": 92, "hrvFactorFeedback": "GOOD", "hrvWeeklyAverage": 53,
+        "sleepHistoryFactorPercent": 92, "sleepHistoryFactorFeedback": "VERY_GOOD",
+        "validSleep": true, "inputContext": "AFTER_WAKEUP_RESET", "primaryActivityTracker":
+        true, "recoveryTimeChangePhrase": "NO_CHANGE_SLEEP"}, {"userProfilePK": 131234790,
+        "calendarDate": "2025-07-07", "timestamp": "2025-07-06T22:39:28.0", "timestampLocal":
+        "2025-07-07T00:39:28.0", "deviceId": 3477316333, "level": "HIGH", "feedbackLong":
+        "HIGH_RT_AVAILABLE_SS_UNKNOWN_ACWR_POS", "feedbackShort": "WELL_RECOVERED",
+        "score": 94, "sleepScore": null, "sleepScoreFactorPercent": 0, "sleepScoreFactorFeedback":
+        "NONE", "recoveryTime": 0, "recoveryTimeFactorPercent": 100, "recoveryTimeFactorFeedback":
+        "VERY_GOOD", "acwrFactorPercent": 100, "acwrFactorFeedback": "VERY_GOOD",
+        "acuteLoad": 24, "stressHistoryFactorPercent": 79, "stressHistoryFactorFeedback":
+        "GOOD", "hrvFactorPercent": 87, "hrvFactorFeedback": "GOOD", "hrvWeeklyAverage":
+        53, "sleepHistoryFactorPercent": 92, "sleepHistoryFactorFeedback": "VERY_GOOD",
+        "validSleep": false, "inputContext": "UPDATE_REALTIME_VARIABLES", "primaryActivityTracker":
+        true, "recoveryTimeChangePhrase": null}]'
+    headers:
+      CF-RAY:
+      - 95ca3893bbf8b391-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 09 Jul 2025 19:27:50 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=Jjp7S6%2B4LEL1U7TCN6nbivRy55BkoF4oDVVGEY4G57y5VRyUUKAmulca9ZuF9lRAWPQrL1GVYkoS2ejn0HMVHHVXoMxVfPDx6ccbyjIAFSRauTsBdTsnh1MHYE7q3e3jQPIQuNVvzg%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - _cfuvid=SANITIZED; path=SANITIZED; domain=SANITIZED; HttpOnly; Secure; SameSite=SANITIZED
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+      - keep-alive
+      Cookie:
+      - _cfuvid=SANITIZED
+      User-Agent:
+      - GCM-iOS-5.7.2.1
+    method: GET
+    uri: https://connectapi.garmin.com/metrics-service/metrics/trainingreadiness/2024-07-07
+  response:
+    body:
+      string: '[]'
+    headers:
+      CF-RAY:
+      - 95ca38960a7eb380-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 09 Jul 2025 19:27:50 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=cmP7MAp6eVfqucUPfk81%2BXJi%2F8cBsreNYg%2BARnXAh8wzpE5nrQkt7cz9notfNjl2leE2ZgMuT6OIYfpexAuZOq9hW8mEbjgZu1xWLIY17guAyjaC0OgLjXZ8EThiobfCq%2FSChceHOA%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/data/cassettes/test_morning_training_readiness_data_list.yaml
+++ b/tests/data/cassettes/test_morning_training_readiness_data_list.yaml
@@ -1,0 +1,151 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - GCM-iOS-5.7.2.1
+    method: GET
+    uri: https://connectapi.garmin.com/metrics-service/metrics/trainingreadiness/2025-07-07
+  response:
+    body:
+      string: '[{"userProfilePK": 131234790, "calendarDate": "2025-07-07", "timestamp":
+        "2025-07-07T17:43:54.0", "timestampLocal": "2025-07-07T19:43:54.0", "deviceId":
+        3345342345, "level": "PRIME", "feedbackLong": "PRIME_RT_HIGHEST_SS_AVAILABLE_ACWR_POS",
+        "feedbackShort": "READY_FOR_ACTION", "score": 100, "sleepScore": 80, "sleepScoreFactorPercent":
+        70, "sleepScoreFactorFeedback": "GOOD", "recoveryTime": 1, "recoveryTimeFactorPercent":
+        99, "recoveryTimeFactorFeedback": "GOOD", "acwrFactorPercent": 100, "acwrFactorFeedback":
+        "VERY_GOOD", "acuteLoad": 20, "stressHistoryFactorPercent": 72, "stressHistoryFactorFeedback":
+        "GOOD", "hrvFactorPercent": 92, "hrvFactorFeedback": "GOOD", "hrvWeeklyAverage":
+        53, "sleepHistoryFactorPercent": 92, "sleepHistoryFactorFeedback": "VERY_GOOD",
+        "validSleep": true, "inputContext": "AFTER_POST_EXERCISE_RESET", "primaryActivityTracker":
+        true, "recoveryTimeChangePhrase": "REACHED_ZERO"}, {"userProfilePK": 131234790,
+        "calendarDate": "2025-07-07", "timestamp": "2025-07-07T04:00:25.0", "timestampLocal":
+        "2025-07-07T06:00:25.0", "deviceId": 3345342345, "level": "PRIME", "feedbackLong":
+        "PRIME_RT_HIGHEST_SS_AVAILABLE_ACWR_POS", "feedbackShort": "READY_FOR_ACTION",
+        "score": 100, "sleepScore": 80, "sleepScoreFactorPercent": 70, "sleepScoreFactorFeedback":
+        "GOOD", "recoveryTime": 1, "recoveryTimeFactorPercent": 99, "recoveryTimeFactorFeedback":
+        "GOOD", "acwrFactorPercent": 100, "acwrFactorFeedback": "VERY_GOOD", "acuteLoad":
+        20, "stressHistoryFactorPercent": 72, "stressHistoryFactorFeedback": "GOOD",
+        "hrvFactorPercent": 92, "hrvFactorFeedback": "GOOD", "hrvWeeklyAverage": 53,
+        "sleepHistoryFactorPercent": 92, "sleepHistoryFactorFeedback": "VERY_GOOD",
+        "validSleep": true, "inputContext": "AFTER_WAKEUP_RESET", "primaryActivityTracker":
+        true, "recoveryTimeChangePhrase": "NO_CHANGE_SLEEP"}, {"userProfilePK": 131234790,
+        "calendarDate": "2025-07-07", "timestamp": "2025-07-06T22:39:28.0", "timestampLocal":
+        "2025-07-07T00:39:28.0", "deviceId": 3345342345, "level": "HIGH", "feedbackLong":
+        "HIGH_RT_AVAILABLE_SS_UNKNOWN_ACWR_POS", "feedbackShort": "WELL_RECOVERED",
+        "score": 94, "sleepScore": null, "sleepScoreFactorPercent": 0, "sleepScoreFactorFeedback":
+        "NONE", "recoveryTime": 0, "recoveryTimeFactorPercent": 100, "recoveryTimeFactorFeedback":
+        "VERY_GOOD", "acwrFactorPercent": 100, "acwrFactorFeedback": "VERY_GOOD",
+        "acuteLoad": 24, "stressHistoryFactorPercent": 79, "stressHistoryFactorFeedback":
+        "GOOD", "hrvFactorPercent": 87, "hrvFactorFeedback": "GOOD", "hrvWeeklyAverage":
+        53, "sleepHistoryFactorPercent": 92, "sleepHistoryFactorFeedback": "VERY_GOOD",
+        "validSleep": false, "inputContext": "UPDATE_REALTIME_VARIABLES", "primaryActivityTracker":
+        true, "recoveryTimeChangePhrase": null}]'
+    headers:
+      CF-RAY:
+      - 95d8ecf8fb8cf98c-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 11 Jul 2025 14:17:40 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=klo8Y2fOoFs1Fk3Xvf2V%2F0uvJJS84SKEmffnXoGhq2z9dVu%2BhS4uUbfpagfzhpu%2FhCxsRsoXL6ABjJ3ehKOrw1ggv9o5p%2FHUcolb5K5D7PvGkbN%2FDk5qVq9SOWh5UWVtVISZdWxSkQ%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - _cfuvid=SANITIZED; path=SANITIZED; domain=SANITIZED; HttpOnly; Secure; SameSite=SANITIZED
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer SANITIZED
+      Connection:
+      - keep-alive
+      Cookie:
+      - _cfuvid=SANITIZED
+      User-Agent:
+      - GCM-iOS-5.7.2.1
+    method: GET
+    uri: https://connectapi.garmin.com/metrics-service/metrics/trainingreadiness/2025-07-06
+  response:
+    body:
+      string: '[{"userProfilePK": 131234790, "calendarDate": "2025-07-06", "timestamp":
+        "2025-07-06T05:59:18.0", "timestampLocal": "2025-07-06T07:59:18.0", "deviceId":
+        3345342345, "level": "PRIME", "feedbackLong": "PRIME_RT_HIGHEST_SS_AVAILABLE_ACWR_POS",
+        "feedbackShort": "READY_FOR_ACTION", "score": 100, "sleepScore": 91, "sleepScoreFactorPercent":
+        91, "sleepScoreFactorFeedback": "VERY_GOOD", "recoveryTime": 0, "recoveryTimeFactorPercent":
+        100, "recoveryTimeFactorFeedback": "VERY_GOOD", "acwrFactorPercent": 100,
+        "acwrFactorFeedback": "VERY_GOOD", "acuteLoad": 24, "stressHistoryFactorPercent":
+        79, "stressHistoryFactorFeedback": "GOOD", "hrvFactorPercent": 89, "hrvFactorFeedback":
+        "GOOD", "hrvWeeklyAverage": 53, "sleepHistoryFactorPercent": 92, "sleepHistoryFactorFeedback":
+        "VERY_GOOD", "validSleep": true, "inputContext": "AFTER_WAKEUP_RESET", "primaryActivityTracker":
+        true, "recoveryTimeChangePhrase": "REACHED_ZERO"}, {"userProfilePK": 131234790,
+        "calendarDate": "2025-07-06", "timestamp": "2025-07-05T22:39:28.0", "timestampLocal":
+        "2025-07-06T00:39:28.0", "deviceId": 3345342345, "level": "HIGH", "feedbackLong":
+        "HIGH_RT_AVAILABLE_SS_UNKNOWN_ACWR_POS", "feedbackShort": "WELL_RECOVERED",
+        "score": 94, "sleepScore": null, "sleepScoreFactorPercent": 0, "sleepScoreFactorFeedback":
+        "NONE", "recoveryTime": 0, "recoveryTimeFactorPercent": 100, "recoveryTimeFactorFeedback":
+        "VERY_GOOD", "acwrFactorPercent": 100, "acwrFactorFeedback": "VERY_GOOD",
+        "acuteLoad": 28, "stressHistoryFactorPercent": 73, "stressHistoryFactorFeedback":
+        "GOOD", "hrvFactorPercent": 92, "hrvFactorFeedback": "GOOD", "hrvWeeklyAverage":
+        53, "sleepHistoryFactorPercent": 92, "sleepHistoryFactorFeedback": "VERY_GOOD",
+        "validSleep": false, "inputContext": "UPDATE_REALTIME_VARIABLES", "primaryActivityTracker":
+        true, "recoveryTimeChangePhrase": null}]'
+    headers:
+      CF-RAY:
+      - 95d8ecfa4db28b99-PRG
+      Cache-Control:
+      - no-cache, no-store, private
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 11 Jul 2025 14:17:40 GMT
+      NEL:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=%2BW9Gq40zGYna1vWf0YNbEFVFWZr6cldvSJKZjWYCNu2SSGhOsfbxFiCpbCWfpe4EaY2TWP4%2B2L0AdeUuR1jPMvVQJYQBftjEobmV9pWqy1SKZVzDz8aVrnnQyFQE5JofAZtovCDW%2Bw%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      pragma:
+      - no-cache
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/data/test_garmin_scores.py
+++ b/tests/data/test_garmin_scores.py
@@ -1,0 +1,34 @@
+from datetime import date
+
+import pytest
+
+from garth import GarminScoresData
+from garth.http import Client
+
+
+@pytest.mark.vcr
+def test_garmin_scores_data_get(authed_client: Client):
+    garmin_scores_data = GarminScoresData.get(
+        "2025-07-07", client=authed_client
+    )
+    assert garmin_scores_data
+    assert garmin_scores_data.calendar_date == date(2025, 7, 7)
+    assert garmin_scores_data.vo_2_max
+    assert garmin_scores_data.endurance_score
+    assert garmin_scores_data.hill_score
+
+    garmin_scores_data_none = GarminScoresData.get(
+        "2024-07-07", client=authed_client
+    )
+    assert garmin_scores_data_none is None
+
+
+@pytest.mark.vcr
+def test_garmin_scores_data_list(authed_client: Client):
+    days = 2
+    end = date(2025, 7, 7)
+    garmin_scores = GarminScoresData.list(
+        end, days, client=authed_client, max_workers=1
+    )
+    assert len(garmin_scores) == days
+    assert garmin_scores[-1].calendar_date == end

--- a/tests/data/test_morning_training_readiness.py
+++ b/tests/data/test_morning_training_readiness.py
@@ -1,0 +1,34 @@
+from datetime import date
+
+import pytest
+
+from garth import MorningTrainingReadinessData
+from garth.http import Client
+
+
+@pytest.mark.vcr
+def test_morning_training_readiness_data_get(authed_client: Client):
+    morning_training_readiness_data = MorningTrainingReadinessData.get(
+        "2025-07-07", client=authed_client
+    )
+    assert morning_training_readiness_data
+    assert morning_training_readiness_data.calendar_date == date(2025, 7, 7)
+    assert morning_training_readiness_data.score
+    assert morning_training_readiness_data.acute_load
+    assert morning_training_readiness_data.sleep_history_factor_percent
+
+    morning_training_readiness_data_none = MorningTrainingReadinessData.get(
+        "2024-07-07", client=authed_client
+    )
+    assert morning_training_readiness_data_none is None
+
+
+@pytest.mark.vcr
+def test_morning_training_readiness_data_list(authed_client: Client):
+    days = 2
+    end = date(2025, 7, 7)
+    morning_training_readiness = MorningTrainingReadinessData.list(
+        end, days, client=authed_client, max_workers=1
+    )
+    assert len(morning_training_readiness) == days
+    assert morning_training_readiness[-1].calendar_date == end


### PR DESCRIPTION
Hi, matin, 
I've added a couple of additional metrics, which can be obtained from the Garmin API. I believe they could be of use to people, who process the data themselves.

Let me know, what you think!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving Garmin fitness scores and morning training readiness data, including detailed metrics and feedback for specific dates or date ranges.

* **Documentation**
  * Expanded documentation with examples and detailed descriptions for accessing Garmin Scores and Morning Training Readiness data.

* **Tests**
  * Introduced tests to verify correct retrieval and handling of Garmin Scores and Morning Training Readiness data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->