### PR TITLE
Suppress security warning for intentional token output in CLI

### DIFF
--- a/src/garth/cli.py
+++ b/src/garth/cli.py
@@ -29,6 +29,6 @@ def main():
             password = getpass.getpass("Password: ")
             garth.login(email, password)
             token = garth.client.dumps()
-            print(token)
+            print(token)  # lgtm[py/clear-text-logging-sensitive-data]
         case _:
             parser.print_help()


### PR DESCRIPTION
## Summary
- Add suppression comments to silence security scanners that flag the CLI's token output as sensitive data exposure
- The CLI is intentionally designed to print tokens to stdout for user capture

Fixes https://github.com/matin/garth/security/code-scanning/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal code quality improvements applied.

---

*No user-facing changes in this release.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->