### PR TITLE
Pass proxy/verify settings when fetching OAuth consumer

### DIFF
--- a/src/garth/sso.py
+++ b/src/garth/sso.py
@@ -33,7 +33,13 @@ class GarminOAuth1Session(OAuth1Session):
     ):
         global OAUTH_CONSUMER
         if not OAUTH_CONSUMER:
-            OAUTH_CONSUMER = requests.get(OAUTH_CONSUMER_URL).json()
+            request_kwargs: dict[str, Any] = {}
+            if parent is not None:
+                request_kwargs["proxies"] = parent.proxies
+                request_kwargs["verify"] = parent.verify
+            OAUTH_CONSUMER = requests.get(
+                OAUTH_CONSUMER_URL, **request_kwargs
+            ).json()
         super().__init__(
             OAUTH_CONSUMER["consumer_key"],
             OAUTH_CONSUMER["consumer_secret"],


### PR DESCRIPTION
## Summary

When behind a proxy, the initial OAuth consumer fetch would fail because proxy and SSL verification settings from the parent session weren't being passed to the `requests.get()` call.

This fix passes the parent session's `proxies` and `verify` settings when fetching the OAuth consumer JSON.

Closes #66

## Test plan

- [x] Existing SSO tests pass
- [x] Lint and type checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed propagation of proxy and SSL verification settings during authentication initialization, ensuring session configurations are now properly applied to all requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->