### PR TITLE
Fix duplicate field alias in WeightData

### DIFF
--- a/src/garth/data/weight.py
+++ b/src/garth/data/weight.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from itertools import chain
 
 from pydantic import Field, ValidationInfo, field_validator
@@ -22,7 +22,6 @@ class WeightData(Data):
     source_type: str
     weight_delta: float
     timestamp_gmt: int
-    datetime_utc: datetime = Field(..., alias="timestamp_gmt")
     datetime_local: datetime = Field(..., alias="date")
     bmi: float | None = None
     body_fat: float | None = None
@@ -37,6 +36,13 @@ class WeightData(Data):
     @classmethod
     def to_localized_datetime(cls, v: int, info: ValidationInfo) -> datetime:
         return get_localized_datetime(info.data["timestamp_gmt"], v)
+
+    @property
+    def datetime_utc(self) -> datetime:
+        """Convert timestamp_gmt to a UTC datetime."""
+        return datetime.fromtimestamp(
+            self.timestamp_gmt / 1000, tz=timezone.utc
+        )
 
     @classmethod
     def get(


### PR DESCRIPTION
## Summary
- Fixes duplicate parameter name error in `WeightData` dataclass
- The class had both `timestamp_gmt: int` and `datetime_utc: datetime = Field(..., alias="timestamp_gmt")` which caused a Pydantic error:
  ```
  ValueError: duplicate parameter name: 'timestamp_gmt'
  ```
- Converted `datetime_utc` to a computed `@property` that derives from `timestamp_gmt`

Fixes #157

## Test plan
- [x] All 112 existing tests pass
- [x] Weight data tests verify the fix works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal datetime handling for weight data to ensure consistent UTC timezone conversion without user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->