### PR TITLE
Remove 429 from default retry status codes (#176)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,11 +52,16 @@ Configure automatic retry behavior for failed requests:
 
 ```python
 garth.configure(
-    retries=5,                              # Max retry attempts (default: 3)
-    status_forcelist=(429, 500, 502, 503),  # HTTP codes to retry
-    backoff_factor=1.0,                     # Delay multiplier between retries
+    retries=5,                            # Max retry attempts (default: 3)
+    status_forcelist=(408, 500, 502, 503, 504),  # HTTP codes to retry
+    backoff_factor=1.0,                   # Delay multiplier between retries
 )
 ```
+
+!!! note "429 not retried by default"
+    HTTP 429 (Too Many Requests) is not in the default retry list because
+    retrying can make rate limiting worse. Add it explicitly if needed:
+    `status_forcelist=(408, 429, 500, 502, 503, 504)`
 
 ## Connection Pool Settings
 

--- a/src/garth/http.py
+++ b/src/garth/http.py
@@ -24,7 +24,7 @@ class Client:
     oauth2_token: OAuth2Token | dict[str, Any] | None = None
     timeout: int = 10
     retries: int = 3
-    status_forcelist: tuple[int, ...] = (408, 429, 500, 502, 503, 504)
+    status_forcelist: tuple[int, ...] = (408, 500, 502, 503, 504)
     backoff_factor: float = 0.5
     pool_connections: int = 10
     pool_maxsize: int = 10

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -162,7 +162,7 @@ def test_configure_retry(client: Client):
 
 
 def test_configure_status_forcelist(client: Client):
-    assert client.status_forcelist == (408, 429, 500, 502, 503, 504)
+    assert client.status_forcelist == (408, 500, 502, 503, 504)
     adapter = client.sess.adapters["https://"]
     assert isinstance(adapter, HTTPAdapter)
     assert adapter.max_retries.status_forcelist == client.status_forcelist


### PR DESCRIPTION
## Summary
- Remove HTTP 429 (Too Many Requests) from the default `status_forcelist`
- Retrying on 429 can make rate limiting situations worse, especially during MFA flows
- Users can still add 429 explicitly if needed via `garth.configure()`

## Test plan
- [x] Updated test for default `status_forcelist`
- [x] All 130 tests pass

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated HTTP retry configuration guidance to clarify that HTTP 429 (Too Many Requests) responses are not retried by default and must be explicitly configured if desired.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->