### PR TITLE
Fix activity_id type to accept int from Garmin API

### DIFF
--- a/src/garth/data/body_battery/events.py
+++ b/src/garth/data/body_battery/events.py
@@ -34,7 +34,7 @@ class BodyBatteryData(Data):
     event: BodyBatteryEvent | None = None
     activity_name: str | None = None
     activity_type: str | None = None
-    activity_id: str | None = None
+    activity_id: str | int | None = None
     average_stress: float | None = None
     stress_values_array: list[list[int]] | None = None
     body_battery_values_array: list[list[Any]] | None = None


### PR DESCRIPTION
## Summary
- Fix `BodyBatteryData.activity_id` type annotation to accept `int` in addition to `str`
- Garmin API returns `activity_id` as an integer for activity events (e.g., Yoga)

Fixes #179

## Test plan
- [x] Existing tests pass
- [x] Type change is backwards compatible (still accepts `str` and `None`)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed body battery activity tracking to properly support numeric activity identifiers alongside text-based ones.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->