### PR TITLE
Revive garth: replace HTTP transport with Camoufox browser automation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,17 +6,16 @@ authors = [
     {name = "Matin Tamizi", email = "mtamizi@duck.com"},
 ]
 dependencies = [
-    "requests>=2.0.0,<3.0.0",
     "pydantic>=2.0.0,<3.0.0",
     "pydantic-settings>=2.0.0,<3.0.0",
-    "requests-oauthlib>=1.3.1,<3.0.0",
-    "logfire>=2.11,<5.0",
+    "camoufox>=0.4",
+    "playwright>=1.40",
 ]
 requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "MIT"}
 classifiers = [
-    "Development Status :: 7 - Inactive",
+    "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -89,7 +88,7 @@ testing = [
     "coverage",
     "freezegun",
     "pytest",
-    "pytest-vcr",
+    "pyyaml>=6.0",
     "logfire>=2.11,<5.0",
 ]
 

--- a/src/garth/__init__.py
+++ b/src/garth/__init__.py
@@ -1,5 +1,3 @@
-import warnings
-
 from .data import (
     Activity,
     BodyBatteryData,
@@ -16,6 +14,7 @@ from .data import (
     WeightData,
 )
 from .http import Client, client
+from .sso import close
 from .stats import (
     DailyHRV,
     DailyHydration,
@@ -32,14 +31,6 @@ from .stats import (
 )
 from .users import UserProfile, UserSettings
 from .version import __version__
-
-
-warnings.warn(
-    "Garth is deprecated and no longer maintained. "
-    "See https://github.com/matin/garth/discussions/222",
-    DeprecationWarning,
-    stacklevel=2,
-)
 
 
 __all__ = [
@@ -73,6 +64,7 @@ __all__ = [
     "WeightData",
     "__version__",
     "client",
+    "close",
     "configure",
     "connectapi",
     "download",

--- a/src/garth/data/_base.py
+++ b/src/garth/data/_base.py
@@ -1,6 +1,5 @@
 import builtins
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor
 from datetime import date
 from itertools import chain
 
@@ -9,8 +8,9 @@ from typing_extensions import Self
 from .. import http
 from ..utils import date_range, format_end_date
 
-
-MAX_WORKERS = 10
+# Kept for backward compatibility — thread pool is no longer used
+# since browser transport cannot be called from multiple threads.
+MAX_WORKERS = 1
 
 
 class Data(ABC):
@@ -30,22 +30,28 @@ class Data(ABC):
         days: int = 1,
         *,
         client: http.Client | None = None,
-        max_workers: int = MAX_WORKERS,
+        max_workers: int = 1,
     ) -> builtins.list[Self]:
+        """Fetch data for multiple dates sequentially.
+
+        Note:
+            The max_workers parameter is accepted for backward
+            compatibility but ignored. All requests go through a
+            single browser page and cannot be parallelized.
+        """
         client = client or http.client
         end = format_end_date(end)
 
-        def fetch_date(date_):
-            if day := cls.get(date_, client=client):
-                return day
-
         dates = date_range(end, days)
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            data = list(executor.map(fetch_date, dates))
-            data = [day for day in data if day is not None]
+        data = []
+        for date_ in dates:
+            day = cls.get(date_, client=client)
+            if day is not None:
+                data.append(day)
 
         return list(
             chain.from_iterable(
-                day if isinstance(day, list) else [day] for day in data
+                day if isinstance(day, list) else [day]
+                for day in data
             )
         )

--- a/src/garth/exc.py
+++ b/src/garth/exc.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
 
-from requests import HTTPError
-
 
 @dataclass
 class GarthException(Exception):
@@ -15,7 +13,7 @@ class GarthException(Exception):
 
 @dataclass
 class GarthHTTPError(GarthException):
-    error: HTTPError
+    error: Exception
 
     def __str__(self) -> str:
         return f"{self.msg}: {self.error}"

--- a/src/garth/http.py
+++ b/src/garth/http.py
@@ -1,23 +1,20 @@
 import base64
 import json
+import logging
 import os
 from collections.abc import Callable
 from typing import IO, Any, Literal
-from urllib.parse import urljoin
 
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from requests import HTTPError, Response, Session
-from requests.adapters import HTTPAdapter, Retry
 
 from . import sso
 from .auth_tokens import OAuth1Token, OAuth2Token
 from .exc import GarthException, GarthHTTPError
-from .telemetry import Telemetry
 from .utils import asdict
 
+log = logging.getLogger(__name__)
 
-USER_AGENT = {"User-Agent": "GCM-iOS-5.22.1.4"}
 OAUTH1_TOKEN_FILE = "oauth1_token.json"
 OAUTH2_TOKEN_FILE = "oauth2_token.json"
 
@@ -37,9 +34,52 @@ class GarthSettings(BaseSettings):
         return self
 
 
+class _Response:
+    """Response wrapper compatible with garth's existing API.
+
+    Note:
+        This is not thread-safe. Playwright browser pages cannot be
+        shared across threads.
+    """
+
+    def __init__(
+        self, status_code: int, text: str, url: str
+    ) -> None:
+        self.status_code = status_code
+        self.text = text
+        self.url = url
+        self.ok = 200 <= status_code < 300
+        self.content = (
+            text.encode() if isinstance(text, str) else b""
+        )
+
+    def json(self) -> Any:
+        return json.loads(self.text)
+
+    def raise_for_status(self) -> None:
+        if not self.ok:
+            raise GarthHTTPError(
+                msg="Error in request",
+                error=Exception(
+                    f"{self.status_code} for url: {self.url}"
+                ),
+            )
+
+
 class Client:
-    sess: Session
-    last_resp: Response
+    """Garmin Connect API client using browser-based transport.
+
+    All HTTP requests are routed through a Camoufox headless browser
+    via ``page.evaluate(fetch(...))``, bypassing Cloudflare bot
+    detection.
+
+    Note:
+        This client is **not thread-safe**. Playwright browser pages
+        cannot be shared across threads. If you need concurrent
+        access, use separate Client instances in separate processes.
+    """
+
+    last_resp: _Response | None = None
     domain: str = "garmin.com"
     oauth1_token: OAuth1Token | Literal["needs_mfa"] | None = None
     oauth2_token: OAuth2Token | dict[str, Any] | None = None
@@ -51,21 +91,9 @@ class Client:
     pool_maxsize: int = 10
     _user_profile: dict[str, Any] | None = None
     _garth_home: str | None = None
-    telemetry: Telemetry
 
-    def __init__(self, session: Session | None = None, **kwargs):
-        self.sess = session if session else Session()
-        self.sess.headers.update(USER_AGENT)
-        self.telemetry = Telemetry()
-        self.configure(
-            timeout=self.timeout,
-            retries=self.retries,
-            status_forcelist=self.status_forcelist,
-            backoff_factor=self.backoff_factor,
-            **kwargs,
-        )
-        if self.telemetry.enabled:
-            print(f"Garth session: {self.telemetry.session_id}")
+    def __init__(self, **kwargs):
+        self.configure(**kwargs)
         self._auto_resume()
 
     def configure(
@@ -82,10 +110,7 @@ class Client:
         backoff_factor: float | None = None,
         pool_connections: int | None = None,
         pool_maxsize: int | None = None,
-        telemetry_enabled: bool | None = None,
-        telemetry_send_to_logfire: bool | None = None,
-        telemetry_token: str | None = None,
-        telemetry_callback: Callable[[dict], None] | None = None,
+        **kwargs,
     ):
         if oauth1_token is not None:
             self.oauth1_token = oauth1_token
@@ -94,9 +119,13 @@ class Client:
         if domain:
             self.domain = domain
         if proxies is not None:
-            self.sess.proxies.update(proxies)
+            log.warning(
+                "proxies not supported with browser transport"
+            )
         if ssl_verify is not None:
-            self.sess.verify = ssl_verify
+            log.warning(
+                "ssl_verify not supported with browser transport"
+            )
         if timeout is not None:
             self.timeout = timeout
         if retries is not None:
@@ -110,33 +139,14 @@ class Client:
         if pool_maxsize is not None:
             self.pool_maxsize = pool_maxsize
 
-        retry = Retry(
-            total=self.retries,
-            status_forcelist=self.status_forcelist,
-            backoff_factor=self.backoff_factor,
-        )
-        adapter = HTTPAdapter(
-            max_retries=retry,
-            pool_connections=self.pool_connections,
-            pool_maxsize=self.pool_maxsize,
-        )
-        self.sess.mount("https://", adapter)
-
-        self.telemetry.configure(
-            enabled=telemetry_enabled,
-            send_to_logfire=telemetry_send_to_logfire,
-            token=telemetry_token,
-            callback=telemetry_callback,
-        )
-        self.telemetry.attach(self.sess)
-
     def _auto_resume(self):
-        """Auto-resume session from GARTH_HOME or GARTH_TOKEN env vars."""
+        """Auto-resume session from GARTH_HOME or GARTH_TOKEN."""
         settings = GarthSettings()
         if settings.home:
             self._garth_home = settings.home
             token_path = os.path.join(
-                os.path.expanduser(settings.home), OAUTH1_TOKEN_FILE
+                os.path.expanduser(settings.home),
+                OAUTH1_TOKEN_FILE,
             )
             if os.path.exists(token_path):
                 self.load(settings.home)
@@ -146,8 +156,12 @@ class Client:
     @property
     def user_profile(self):
         if not self._user_profile:
-            result = self.connectapi("/userprofile-service/socialProfile")
-            assert isinstance(result, dict), "No profile from connectapi"
+            result = self.connectapi(
+                "/userprofile-service/socialProfile"
+            )
+            assert isinstance(result, dict), (
+                "No profile from connectapi"
+            )
             self._user_profile = result
         return self._user_profile
 
@@ -169,47 +183,170 @@ class Client:
         referrer: str | bool = False,
         headers: dict = {},
         **kwargs,
-    ) -> Response:
-        url = f"https://{subdomain}.{self.domain}"
-        url = urljoin(url, path)
-        if referrer is True and self.last_resp:
-            headers["referer"] = self.last_resp.url
-        if api:
-            assert self.oauth1_token, (
-                "OAuth1 token is required for API requests"
-            )
-            if (
-                not isinstance(self.oauth2_token, OAuth2Token)
-                or self.oauth2_token.expired
-            ):
-                self.refresh_oauth2()
-            headers["Authorization"] = str(self.oauth2_token)
-        self.last_resp = self.sess.request(
-            method,
-            url,
-            headers=headers,
-            timeout=self.timeout,
-            **kwargs,
-        )
-        try:
-            self.last_resp.raise_for_status()
-        except HTTPError as e:
-            raise GarthHTTPError(
-                msg="Error in request",
-                error=e,
-            )
-        return self.last_resp
+    ) -> _Response:
+        """Make an API request through the browser.
 
-    def get(self, *args, **kwargs) -> Response:
+        All requests are routed through ``page.evaluate(fetch(...))``
+        in the Camoufox browser, bypassing Cloudflare.
+        """
+        page = sso.get_page()
+        csrf = sso.get_csrf()
+
+        if not page:
+            raise GarthException(
+                msg="Not logged in — call login() first"
+            )
+
+        url = f"/gc-api/{path.lstrip('/')}"
+
+        params = kwargs.get("params")
+        if params:
+            from urllib.parse import urlencode
+            url += "?" + urlencode(params)
+
+        json_body = kwargs.get("json")
+        data = kwargs.get("data")
+
+        # Handle file uploads
+        files = kwargs.get("files")
+        if files:
+            if len(files) > 1:
+                raise GarthException(
+                    msg="Only single file upload is supported"
+                )
+            return self._upload_via_browser(
+                page, csrf, url, files
+            )
+
+        result = page.evaluate("""
+            async ([url, method, jsonBody, formData, csrf,
+                    extraHeaders]) => {
+                const h = {
+                    'connect-csrf-token': csrf || '',
+                    'Accept': 'application/json'
+                };
+                if (extraHeaders) {
+                    Object.assign(h, extraHeaders);
+                }
+                let body = undefined;
+                if (jsonBody) {
+                    h['Content-Type'] = 'application/json';
+                    body = JSON.stringify(jsonBody);
+                } else if (formData) {
+                    h['Content-Type'] =
+                        'application/x-www-form-urlencoded';
+                    body = formData;
+                }
+                try {
+                    const resp = await fetch(url, {
+                        method: method || 'GET',
+                        credentials: 'include',
+                        headers: h,
+                        body: body
+                    });
+                    const text = await resp.text();
+                    return {
+                        status: resp.status,
+                        text: text,
+                        url: resp.url
+                    };
+                } catch(e) {
+                    return {status: 0, error: e.message};
+                }
+            }
+        """, [
+            url,
+            method.upper(),
+            json_body,
+            data if isinstance(data, str) else None,
+            csrf,
+            headers if headers else None,
+        ])
+
+        if result.get("error"):
+            raise GarthHTTPError(
+                msg=f"Browser fetch error: {result['error']}",
+                error=Exception(result["error"]),
+            )
+
+        status = result.get("status", 0)
+        text = result.get("text", "")
+        resp_url = result.get("url", "")
+
+        resp = _Response(status, text, resp_url)
+        self.last_resp = resp
+
+        if not resp.ok:
+            resp.raise_for_status()
+
+        return resp
+
+    def _upload_via_browser(
+        self, page, csrf: str, url: str, files: dict
+    ) -> _Response:
+        """Upload a single file via browser FormData."""
+        field_name, (filename, fp) = next(iter(files.items()))
+        file_bytes = fp.read()
+        b64_data = base64.b64encode(file_bytes).decode()
+
+        result = page.evaluate("""
+            async ([url, b64Data, fileName, csrf]) => {
+                const resp = await fetch(
+                    'data:application/octet-stream;base64,'
+                    + b64Data
+                );
+                const blob = await resp.blob();
+                const formData = new FormData();
+                formData.append('file', blob, fileName);
+                try {
+                    const resp = await fetch(url, {
+                        method: 'POST',
+                        credentials: 'include',
+                        headers: {
+                            'connect-csrf-token': csrf || ''
+                        },
+                        body: formData
+                    });
+                    const text = await resp.text();
+                    return {
+                        status: resp.status,
+                        text: text,
+                        url: resp.url
+                    };
+                } catch(e) {
+                    return {status: 0, error: e.message};
+                }
+            }
+        """, [url, b64_data, filename, csrf])
+
+        if result.get("error"):
+            raise GarthHTTPError(
+                msg=f"Upload error: {result['error']}",
+                error=Exception(result["error"]),
+            )
+
+        resp = _Response(
+            result.get("status", 0),
+            result.get("text", ""),
+            result.get("url", ""),
+        )
+        self.last_resp = resp
+
+        if not resp.ok:
+            resp.raise_for_status()
+
+        return resp
+
+    def get(self, *args, **kwargs) -> _Response:
         return self.request("GET", *args, **kwargs)
 
-    def post(self, *args, **kwargs) -> Response:
+    def post(self, *args, **kwargs) -> _Response:
         return self.request("POST", *args, **kwargs)
 
-    def delete(self, *args, **kwargs) -> Response:
+    def delete(self, *args, **kwargs) -> _Response:
         return self.request("DELETE", *args, **kwargs)
 
-    def put(self, *args, **kwargs) -> Response:
+    def put(self, *args, **kwargs) -> _Response:
         return self.request("PUT", *args, **kwargs)
 
     def login(self, *args, **kwargs):
@@ -232,28 +369,83 @@ class Client:
         assert self.oauth1_token and isinstance(
             self.oauth1_token, OAuth1Token
         ), "OAuth1 token is required for OAuth2 refresh"
-        try:
-            self.oauth2_token = sso.exchange(self.oauth1_token, self)
-        except GarthHTTPError:
-            self.oauth1_token = None
-            raise
+        self.oauth2_token = sso.exchange(self.oauth1_token, self)
         if self._garth_home:
             self.dump(self._garth_home, oauth2_only=True)
 
     def connectapi(
         self, path: str, method="GET", **kwargs
     ) -> dict[str, Any] | list[dict[str, Any]] | None:
-        resp = self.request(method, "connectapi", path, api=True, **kwargs)
+        resp = self.request(
+            method, "connectapi", path, api=True, **kwargs
+        )
         if resp.status_code == 204:
             return None
         return resp.json()
 
     def download(self, path: str, **kwargs) -> bytes:
-        resp = self.get("connectapi", path, api=True, **kwargs)
-        return resp.content
+        """Download binary data (FIT files, etc.)."""
+        page = sso.get_page()
+        csrf = sso.get_csrf()
+
+        if not page:
+            raise GarthException(
+                msg="Not logged in — call login() first"
+            )
+
+        url = f"/gc-api/{path.lstrip('/')}"
+
+        result = page.evaluate("""
+            async ([url, csrf]) => {
+                try {
+                    const resp = await fetch(url, {
+                        credentials: 'include',
+                        headers: {
+                            'connect-csrf-token': csrf || ''
+                        }
+                    });
+                    if (resp.status !== 200) {
+                        return {
+                            status: resp.status, data: null
+                        };
+                    }
+                    const blob = await resp.blob();
+                    return await new Promise((resolve) => {
+                        const reader = new FileReader();
+                        reader.onloadend = () => {
+                            const b64 = reader.result
+                                .split(',')[1];
+                            resolve({status: 200, data: b64});
+                        };
+                        reader.readAsDataURL(blob);
+                    });
+                } catch(e) {
+                    return {status: 0, error: e.message};
+                }
+            }
+        """, [url, csrf])
+
+        if result.get("error") or result.get("status") != 200:
+            raise GarthHTTPError(
+                msg=(
+                    "Download failed: "
+                    f"HTTP {result.get('status')}"
+                ),
+                error=Exception(
+                    result.get(
+                        "error",
+                        f"HTTP {result.get('status')}",
+                    )
+                ),
+            )
+
+        return base64.b64decode(result["data"])
 
     def upload(
-        self, fp: IO[bytes], /, path: str = "/upload-service/upload"
+        self,
+        fp: IO[bytes],
+        /,
+        path: str = "/upload-service/upload",
     ) -> dict[str, Any]:
         fname = os.path.basename(fp.name)
         files = {"file": (fname, fp)}
@@ -266,16 +458,26 @@ class Client:
         assert isinstance(result, dict)
         return result
 
-    def dump(self, dir_path: str, /, oauth2_only: bool = False):
+    def dump(
+        self, dir_path: str, /, oauth2_only: bool = False
+    ) -> None:
         dir_path = os.path.expanduser(dir_path)
         os.makedirs(dir_path, exist_ok=True)
         if not oauth2_only:
-            with open(os.path.join(dir_path, OAUTH1_TOKEN_FILE), "w") as f:
+            with open(
+                os.path.join(dir_path, OAUTH1_TOKEN_FILE), "w"
+            ) as f:
                 if self.oauth1_token:
-                    json.dump(asdict(self.oauth1_token), f, indent=4)
-        with open(os.path.join(dir_path, OAUTH2_TOKEN_FILE), "w") as f:
+                    json.dump(
+                        asdict(self.oauth1_token), f, indent=4
+                    )
+        with open(
+            os.path.join(dir_path, OAUTH2_TOKEN_FILE), "w"
+        ) as f:
             if self.oauth2_token:
-                json.dump(asdict(self.oauth2_token), f, indent=4)
+                json.dump(
+                    asdict(self.oauth2_token), f, indent=4
+                )
 
     def dumps(self) -> str:
         r = []
@@ -284,20 +486,45 @@ class Client:
         s = json.dumps(r)
         return base64.b64encode(s.encode()).decode()
 
-    def load(self, dir_path: str):
+    def load(self, dir_path: str) -> None:
         dir_path = os.path.expanduser(dir_path)
-        with open(os.path.join(dir_path, OAUTH1_TOKEN_FILE)) as f:
+        with open(
+            os.path.join(dir_path, OAUTH1_TOKEN_FILE)
+        ) as f:
             oauth1 = OAuth1Token(**json.load(f))
-        with open(os.path.join(dir_path, OAUTH2_TOKEN_FILE)) as f:
+        with open(
+            os.path.join(dir_path, OAUTH2_TOKEN_FILE)
+        ) as f:
             oauth2 = OAuth2Token(**json.load(f))
+
+        # Detect browser-backed placeholder tokens
+        if sso.is_browser_token(oauth1):
+            log.warning(
+                "Loaded browser-session tokens from %s. "
+                "These require an active browser — call login() "
+                "to start a new session.",
+                dir_path,
+            )
+
         self.configure(
-            oauth1_token=oauth1, oauth2_token=oauth2, domain=oauth1.domain
+            oauth1_token=oauth1,
+            oauth2_token=oauth2,
+            domain=oauth1.domain,
         )
 
-    def loads(self, s: str):
+    def loads(self, s: str) -> None:
         oauth1, oauth2 = json.loads(base64.b64decode(s))
+        oauth1_obj = OAuth1Token(**oauth1)
+
+        if sso.is_browser_token(oauth1_obj):
+            log.warning(
+                "Loaded browser-session tokens from string. "
+                "These require an active browser — call login() "
+                "to start a new session."
+            )
+
         self.configure(
-            oauth1_token=OAuth1Token(**oauth1),
+            oauth1_token=oauth1_obj,
             oauth2_token=OAuth2Token(**oauth2),
             domain=oauth1.get("domain"),
         )

--- a/src/garth/http.py
+++ b/src/garth/http.py
@@ -4,6 +4,7 @@ import logging
 import os
 from collections.abc import Callable
 from typing import IO, Any, Literal
+from urllib.parse import urlencode
 
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -110,7 +111,6 @@ class Client:
         backoff_factor: float | None = None,
         pool_connections: int | None = None,
         pool_maxsize: int | None = None,
-        **kwargs,
     ):
         if oauth1_token is not None:
             self.oauth1_token = oauth1_token
@@ -181,14 +181,23 @@ class Client:
         /,
         api: bool = False,
         referrer: str | bool = False,
-        headers: dict = {},
+        headers: dict | None = None,
         **kwargs,
     ) -> _Response:
         """Make an API request through the browser.
 
         All requests are routed through ``page.evaluate(fetch(...))``
         in the Camoufox browser, bypassing Cloudflare.
+
+        Note:
+            The ``subdomain``, ``api``, and ``referrer`` parameters
+            are accepted for backward compatibility. With browser
+            transport, all requests go through the same origin via
+            ``/gc-api/`` prefix.
         """
+        if headers is None:
+            headers = {}
+
         page = sso.get_page()
         csrf = sso.get_csrf()
 
@@ -201,11 +210,16 @@ class Client:
 
         params = kwargs.get("params")
         if params:
-            from urllib.parse import urlencode
-            url += "?" + urlencode(params)
+            url += "?" + urlencode(params, doseq=True)
 
         json_body = kwargs.get("json")
         data = kwargs.get("data")
+
+        # Encode dict data as URL-encoded form
+        if isinstance(data, dict):
+            data = urlencode(data)
+        elif isinstance(data, bytes):
+            data = data.decode("utf-8", errors="replace")
 
         # Handle file uploads
         files = kwargs.get("files")
@@ -215,7 +229,7 @@ class Client:
                     msg="Only single file upload is supported"
                 )
             return self._upload_via_browser(
-                page, csrf, url, files
+                page, csrf or "", url, files
             )
 
         result = page.evaluate("""
@@ -282,10 +296,19 @@ class Client:
         return resp
 
     def _upload_via_browser(
-        self, page, csrf: str, url: str, files: dict
+        self,
+        page,
+        csrf: str | None,
+        url: str,
+        files: dict,
     ) -> _Response:
-        """Upload a single file via browser FormData."""
-        field_name, (filename, fp) = next(iter(files.items()))
+        """Upload a single file via browser FormData.
+
+        Note:
+            The caller-specified field name is ignored; Garmin's
+            upload API expects the field name ``file``.
+        """
+        _field_name, (filename, fp) = next(iter(files.items()))
         file_bytes = fp.read()
         b64_data = base64.b64encode(file_bytes).decode()
 
@@ -299,7 +322,7 @@ class Client:
                 const formData = new FormData();
                 formData.append('file', blob, fileName);
                 try {
-                    const resp = await fetch(url, {
+                    const resp2 = await fetch(url, {
                         method: 'POST',
                         credentials: 'include',
                         headers: {
@@ -307,17 +330,17 @@ class Client:
                         },
                         body: formData
                     });
-                    const text = await resp.text();
+                    const text = await resp2.text();
                     return {
-                        status: resp.status,
+                        status: resp2.status,
                         text: text,
-                        url: resp.url
+                        url: resp2.url
                     };
                 } catch(e) {
                     return {status: 0, error: e.message};
                 }
             }
-        """, [url, b64_data, filename, csrf])
+        """, [url, b64_data, filename, csrf or ""])
 
         if result.get("error"):
             raise GarthHTTPError(

--- a/src/garth/sso.py
+++ b/src/garth/sso.py
@@ -30,6 +30,13 @@ _csrf = None
 BROWSER_TOKEN_SENTINEL = "browser_session"
 
 
+def _connect_base_url(domain: str) -> str:
+    """Return the Connect base URL for a given domain."""
+    if domain == "garmin.cn":
+        return "https://connect.garmin.cn"
+    return "https://connect.garmin.com"
+
+
 def _placeholder_oauth2() -> OAuth2Token:
     """Create a placeholder OAuth2 token for browser-backed sessions.
 
@@ -94,6 +101,7 @@ def login(
     session_dir = Path(session_dir) if session_dir else DEFAULT_SESSION_DIR
     session_dir.mkdir(parents=True, exist_ok=True)
     session_file = session_dir / "browser_session.json"
+    connect_base = _connect_base_url(client.domain)
 
     # Close any existing browser before launching a new one
     close()
@@ -102,43 +110,53 @@ def login(
     from camoufox.sync_api import Camoufox
 
     _cm = Camoufox(headless=headless)
-    _browser = _cm.__enter__()
-    _page = _browser.new_page()
-    context = _page.context
-
-    # Load saved session cookies
-    if session_file.exists():
-        try:
-            session = json.loads(session_file.read_text())
-            age_days = (
-                time.time() - session.get("saved_at", 0)
-            ) / 86400
-            if age_days < 364 and session.get("cookies"):
-                context.add_cookies(session["cookies"])
-                log.info(
-                    "Loaded session cookies (%.0f days old)", age_days
-                )
-        except Exception as e:
-            log.debug("Could not load session cookies: %s", e)
-
-    # Navigate to Garmin Connect
     try:
-        _page.goto(
-            "https://connect.garmin.com/modern/",
-            wait_until="domcontentloaded",
-            timeout=30000,
+        _browser = _cm.__enter__()
+        _page = _browser.new_page()
+        context = _page.context
+
+        # Load saved session cookies
+        if session_file.exists():
+            try:
+                session = json.loads(session_file.read_text())
+                age_days = (
+                    time.time() - session.get("saved_at", 0)
+                ) / 86400
+                if age_days < 364 and session.get("cookies"):
+                    context.add_cookies(session["cookies"])
+                    log.info(
+                        "Loaded session cookies (%.0f days old)",
+                        age_days,
+                    )
+            except Exception as e:
+                log.debug("Could not load session cookies: %s", e)
+
+        # Navigate to Garmin Connect
+        try:
+            _page.goto(
+                f"{connect_base}/modern/",
+                wait_until="domcontentloaded",
+                timeout=30000,
+            )
+        except Exception as e:
+            log.debug(
+                "Initial navigation error (may be expected): %s", e
+            )
+        time.sleep(3)
+
+        # Check if session is valid
+        url = _page.url
+        needs_login = "sso.garmin" in url or not _try_setup(
+            client.domain
         )
-    except Exception as e:
-        log.debug("Initial navigation error (may be expected): %s", e)
-    time.sleep(3)
 
-    # Check if session is valid
-    url = _page.url
-    needs_login = "sso.garmin.com" in url or not _try_setup()
+        if needs_login:
+            _do_login(email, password, prompt_mfa, client.domain)
+            _save_session(session_file)
 
-    if needs_login:
-        _do_login(email, password, prompt_mfa, client.domain)
-        _save_session(session_file)
+    except Exception:
+        close()
+        raise
 
     # Return placeholder tokens — the browser session handles auth
     oauth1 = OAuth1Token(
@@ -223,7 +241,9 @@ def close() -> None:
         try:
             _cm.__exit__(None, None, None)
         except Exception as e:
-            log.debug("Error closing browser context manager: %s", e)
+            log.debug(
+                "Error closing browser context manager: %s", e
+            )
     _cm = None
     _browser = None
     _page = None
@@ -233,14 +253,15 @@ def close() -> None:
 # --- Internal helpers ---
 
 
-def _try_setup() -> bool:
+def _try_setup(domain: str = "garmin.com") -> bool:
     """Extract CSRF token and verify session is valid."""
     global _csrf
+    connect_base = _connect_base_url(domain)
     current = _page.url
     if "/modern/" not in current:
         try:
             _page.goto(
-                "https://connect.garmin.com/modern/",
+                f"{connect_base}/modern/",
                 wait_until="domcontentloaded",
             )
         except Exception as e:
@@ -367,8 +388,12 @@ def _do_login(
                     "if (cb && !cb.checked) cb.click(); }"
                 )
             except Exception as e:
-                log.debug("MFA remember checkbox not found: %s", e)
-            _page.locator('button:has-text("Next")').first.click()
+                log.debug(
+                    "MFA remember checkbox not found: %s", e
+                )
+            _page.locator(
+                'button:has-text("Next")'
+            ).first.click()
 
             # Wait for redirect after MFA
             for _ in range(60):
@@ -379,11 +404,10 @@ def _do_login(
                 ):
                     break
                 try:
-                    has_app = _page.evaluate(
-                        "() => document.body?.innerText"
-                        '?.includes("Activities")'
+                    on_connect = (
+                        connect_domain in _page.url
                     )
-                    if has_app:
+                    if on_connect:
                         _page.goto(
                             f"https://{connect_domain}/modern/",
                             wait_until="domcontentloaded",
@@ -401,7 +425,7 @@ def _do_login(
             msg="Login failed — still on SSO page"
         )
 
-    if not _try_setup():
+    if not _try_setup(domain):
         raise GarthException(
             msg="Login succeeded but could not extract session data"
         )

--- a/src/garth/sso.py
+++ b/src/garth/sso.py
@@ -1,89 +1,53 @@
 from __future__ import annotations
 
-import asyncio
-import inspect
+import json
+import logging
+import os
 import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, Literal
-from urllib.parse import parse_qs
-
-import requests
-from requests import Session
-from requests_oauthlib import OAuth1Session
 
 from . import http
 from .auth_tokens import OAuth1Token, OAuth2Token
 from .exc import GarthException
 
+log = logging.getLogger(__name__)
 
-CLIENT_ID = "GCM_ANDROID_DARK"
-OAUTH_CONSUMER_URL = "https://thegarth.s3.amazonaws.com/oauth_consumer.json"
-OAUTH_CONSUMER: dict[str, str] = {}
+DEFAULT_SESSION_DIR = Path.home() / ".garth"
 
-SSO_SUCCESSFUL = "SUCCESSFUL"
-SSO_MFA_REQUIRED = "MFA_REQUIRED"
+# Browser state — module-level singleton.
+# Limitation: only one active session at a time. This matches garth's
+# existing singleton pattern (garth.client). Multi-account use requires
+# separate Python processes.
+_cm = None  # Camoufox context manager
+_browser = None
+_page = None
+_csrf = None
 
-# Android user agent — must match the Android consumer key from S3
-OAUTH_USER_AGENT = {"User-Agent": "com.garmin.android.apps.connectmobile"}
-
-# Browser-like headers for SSO to avoid Cloudflare challenges.
-# The SSO endpoints run in a WebView, so requests must look like a
-# browser — not a Python HTTP client.
-_SSO_UA = (
-    "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) "
-    "AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
-)
-SSO_PAGE_HEADERS = {
-    "User-Agent": _SSO_UA,
-    "Accept": (
-        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-    ),
-    "Accept-Language": "en-US,en;q=0.9",
-    "Sec-Fetch-Mode": "navigate",
-    "Sec-Fetch-Dest": "document",
-}
+# Sentinel value used to identify browser-backed placeholder tokens.
+# When tokens contain this value, they cannot be used without a browser.
+BROWSER_TOKEN_SENTINEL = "browser_session"
 
 
-class GarminOAuth1Session(OAuth1Session):
-    def __init__(
-        self,
-        /,
-        parent: Session | None = None,
-        **kwargs,
-    ):
-        global OAUTH_CONSUMER
-        if not OAUTH_CONSUMER:
-            request_kwargs: dict[str, Any] = {}
-            if parent is not None:
-                request_kwargs["proxies"] = parent.proxies
-                request_kwargs["verify"] = parent.verify
-            OAUTH_CONSUMER = requests.get(
-                OAUTH_CONSUMER_URL, **request_kwargs
-            ).json()
-        super().__init__(
-            OAUTH_CONSUMER["consumer_key"],
-            OAUTH_CONSUMER["consumer_secret"],
-            **kwargs,
-        )
-        if parent is not None:
-            self.mount("https://", parent.adapters["https://"])
-            self.cookies.update(parent.cookies)
-            self.proxies = parent.proxies
-            self.verify = parent.verify
-            self.hooks["response"].extend(parent.hooks["response"])
+def _placeholder_oauth2() -> OAuth2Token:
+    """Create a placeholder OAuth2 token for browser-backed sessions.
 
-
-def _parse_sso_response(
-    resp_json: dict[str, Any],
-    expected_type: str | None = None,
-) -> dict[str, Any]:
-    status = resp_json.get("responseStatus", {})
-    resp_type = status.get("type", "UNKNOWN")
-    message = status.get("message", "")
-    if expected_type and resp_type != expected_type:
-        detail = f"{resp_type}: {message}" if message else resp_type
-        raise GarthException(msg=f"SSO error: {detail}")
-    return resp_json
+    The browser session handles real auth via cookies. These tokens
+    exist only to satisfy garth's Client interface which expects
+    OAuth tokens to be set after login.
+    """
+    return OAuth2Token(
+        scope="readwrite",
+        jti=BROWSER_TOKEN_SENTINEL,
+        token_type="Bearer",
+        access_token=BROWSER_TOKEN_SENTINEL,
+        refresh_token=BROWSER_TOKEN_SENTINEL,
+        expires_in=86400 * 365,
+        expires_at=int(time.time()) + 86400 * 365,
+        refresh_token_expires_in=86400 * 365,
+        refresh_token_expires_at=int(time.time()) + 86400 * 365,
+    )
 
 
 def login(
@@ -93,81 +57,98 @@ def login(
     client: http.Client | None = None,
     prompt_mfa: Callable | None = lambda: input("MFA code: "),
     return_on_mfa: bool = False,
+    session_dir: str | Path | None = None,
+    headless: bool = True,
 ) -> (
     tuple[OAuth1Token, OAuth2Token]
     | tuple[Literal["needs_mfa"], dict[str, Any]]
 ):
-    client = client or http.client
-    service_url = f"https://mobile.integration.{client.domain}/gcm/android"
-    login_params = {
-        "clientId": CLIENT_ID,
-        "locale": "en-US",
-        "service": service_url,
-    }
+    """Login to Garmin Connect via browser automation.
 
-    # Set cookies
-    client.get(
-        "sso",
-        "/mobile/sso/en/sign-in",
-        params={"clientId": CLIENT_ID},
-        headers={**SSO_PAGE_HEADERS, "Sec-Fetch-Site": "none"},
-    )
+    Uses Camoufox (headless Firefox) to perform SSO login, bypassing
+    Cloudflare bot detection that blocks all Python HTTP clients.
 
-    # Submit login
-    client.post(
-        "sso",
-        "/mobile/api/login",
-        params=login_params,
-        headers=SSO_PAGE_HEADERS,
-        json={
-            "username": email,
-            "password": password,
-            "rememberMe": False,
-            "captchaToken": "",
-        },
-    )
-    resp_json = client.last_resp.json()
-    resp_type = resp_json.get("responseStatus", {}).get("type")
+    Note:
+        This is not thread-safe. Playwright browser pages cannot be
+        shared across threads. Use one Client per thread if needed.
 
-    if resp_type == SSO_SUCCESSFUL:
-        ticket = resp_json["serviceTicketId"]
-        return _complete_login(ticket, client)
+    Args:
+        email: Garmin account email
+        password: Garmin account password
+        client: garth Client instance (used for domain config)
+        prompt_mfa: Callable that returns MFA code when prompted
+        return_on_mfa: Not supported with browser login. Raises
+            NotImplementedError if True.
+        session_dir: Directory to store browser session cookies
+        headless: Run browser without visible window (default: True)
+    """
+    global _cm, _browser, _page, _csrf
 
-    if resp_type == SSO_MFA_REQUIRED:
-        mfa_info = resp_json.get("customerMfaInfo") or {}
-        mfa_method = mfa_info.get("mfaLastMethodUsed") or "email"
-        if return_on_mfa or prompt_mfa is None:
-            return "needs_mfa", {
-                "login_params": login_params,
-                "client": client,
-                "mfa_method": mfa_method,
-            }
-        ticket = handle_mfa(
-            client, login_params, prompt_mfa, mfa_method=mfa_method
+    if return_on_mfa:
+        raise NotImplementedError(
+            "return_on_mfa is not supported with browser-based login. "
+            "MFA is handled interactively via the prompt_mfa callback."
         )
-        return _complete_login(ticket, client)
 
-    _parse_sso_response(resp_json, SSO_SUCCESSFUL)
-    raise GarthException(msg="Unexpected SSO response")  # pragma: no cover
+    client = client or http.client
+    session_dir = Path(session_dir) if session_dir else DEFAULT_SESSION_DIR
+    session_dir.mkdir(parents=True, exist_ok=True)
+    session_file = session_dir / "browser_session.json"
 
+    # Close any existing browser before launching a new one
+    close()
 
-def get_oauth1_token(ticket: str, client: http.Client) -> OAuth1Token:
-    sess = GarminOAuth1Session(parent=client.sess)
-    base_url = f"https://connectapi.{client.domain}/oauth-service/oauth/"
-    login_url = f"https://mobile.integration.{client.domain}/gcm/android"
-    url = (
-        f"{base_url}preauthorized?ticket={ticket}&login-url={login_url}"
-        "&accepts-mfa-tokens=true"
+    # Launch browser via context manager
+    from camoufox.sync_api import Camoufox
+
+    _cm = Camoufox(headless=headless)
+    _browser = _cm.__enter__()
+    _page = _browser.new_page()
+    context = _page.context
+
+    # Load saved session cookies
+    if session_file.exists():
+        try:
+            session = json.loads(session_file.read_text())
+            age_days = (
+                time.time() - session.get("saved_at", 0)
+            ) / 86400
+            if age_days < 364 and session.get("cookies"):
+                context.add_cookies(session["cookies"])
+                log.info(
+                    "Loaded session cookies (%.0f days old)", age_days
+                )
+        except Exception as e:
+            log.debug("Could not load session cookies: %s", e)
+
+    # Navigate to Garmin Connect
+    try:
+        _page.goto(
+            "https://connect.garmin.com/modern/",
+            wait_until="domcontentloaded",
+            timeout=30000,
+        )
+    except Exception as e:
+        log.debug("Initial navigation error (may be expected): %s", e)
+    time.sleep(3)
+
+    # Check if session is valid
+    url = _page.url
+    needs_login = "sso.garmin.com" in url or not _try_setup()
+
+    if needs_login:
+        _do_login(email, password, prompt_mfa, client.domain)
+        _save_session(session_file)
+
+    # Return placeholder tokens — the browser session handles auth
+    oauth1 = OAuth1Token(
+        oauth_token=BROWSER_TOKEN_SENTINEL,
+        oauth_token_secret=BROWSER_TOKEN_SENTINEL,
+        domain=client.domain,
     )
-    resp = sess.get(
-        url,
-        headers=OAUTH_USER_AGENT,
-        timeout=client.timeout,
-    )
-    resp.raise_for_status()
-    parsed = parse_qs(resp.text)
-    token = {k: v[0] for k, v in parsed.items()}
-    return OAuth1Token(domain=client.domain, **token)  # type: ignore
+    oauth2 = _placeholder_oauth2()
+
+    return oauth1, oauth2
 
 
 def exchange(
@@ -176,31 +157,12 @@ def exchange(
     *,
     login: bool = False,
 ) -> OAuth2Token:
-    sess = GarminOAuth1Session(
-        resource_owner_key=oauth1.oauth_token,
-        resource_owner_secret=oauth1.oauth_token_secret,
-        parent=client.sess,
-    )
-    data: dict[str, str] = {}
-    if login:
-        data["audience"] = "GARMIN_CONNECT_MOBILE_ANDROID_DI"
-    if oauth1.mfa_token:
-        data["mfa_token"] = oauth1.mfa_token
-    base_url = f"https://connectapi.{client.domain}/oauth-service/oauth/"
-    url = f"{base_url}exchange/user/2.0"
-    headers = {
-        **OAUTH_USER_AGENT,
-        **{"Content-Type": "application/x-www-form-urlencoded"},
-    }
-    resp = sess.post(
-        url,
-        headers=headers,
-        data=data,
-        timeout=client.timeout,
-    )
-    resp.raise_for_status()
-    token = resp.json()
-    return OAuth2Token(**set_expirations(token))
+    """Refresh OAuth2 token — no-op with browser transport.
+
+    The browser session handles auth via cookies, so token refresh
+    is not needed. Returns a fresh placeholder token.
+    """
+    return _placeholder_oauth2()
 
 
 def handle_mfa(
@@ -210,25 +172,19 @@ def handle_mfa(
     *,
     mfa_method: str = "email",
 ) -> str:
-    if inspect.iscoroutinefunction(prompt_mfa):
-        mfa_code = asyncio.run(prompt_mfa())
-    else:
-        mfa_code = prompt_mfa()
-    client.post(
-        "sso",
-        "/mobile/api/mfa/verifyCode",
-        params=login_params,
-        headers=SSO_PAGE_HEADERS,
-        json={
-            "mfaMethod": mfa_method,
-            "mfaVerificationCode": mfa_code,
-            "rememberMyBrowser": False,
-            "reconsentList": [],
-            "mfaSetup": False,
-        },
+    """Not used with browser transport — MFA is handled in-browser."""
+    raise NotImplementedError(
+        "MFA is handled by the browser login flow"
     )
-    resp_json = _parse_sso_response(client.last_resp.json(), SSO_SUCCESSFUL)
-    return resp_json["serviceTicketId"]
+
+
+def resume_login(
+    client_state: dict, mfa_code: str
+) -> tuple[OAuth1Token, OAuth2Token]:
+    """Not used with browser transport — MFA is handled in-browser."""
+    raise NotImplementedError(
+        "MFA is handled by the browser login flow"
+    )
 
 
 def set_expirations(token: dict) -> dict:
@@ -239,32 +195,235 @@ def set_expirations(token: dict) -> dict:
     return token
 
 
-def resume_login(
-    client_state: dict, mfa_code: str
-) -> tuple[OAuth1Token, OAuth2Token]:
-    client = client_state["client"]
-    login_params = client_state["login_params"]
-    mfa_method = client_state.get("mfa_method", "email")
-    ticket = handle_mfa(
-        client, login_params, lambda: mfa_code, mfa_method=mfa_method
-    )
-    return _complete_login(ticket, client)
+def is_browser_token(token: OAuth1Token | OAuth2Token | None) -> bool:
+    """Check if a token is a browser-backed placeholder."""
+    if token is None:
+        return False
+    if isinstance(token, OAuth1Token):
+        return token.oauth_token == BROWSER_TOKEN_SENTINEL
+    if isinstance(token, OAuth2Token):
+        return token.access_token == BROWSER_TOKEN_SENTINEL
+    return False
 
 
-def _complete_login(
-    ticket: str, client: http.Client
-) -> tuple[OAuth1Token, OAuth2Token]:
-    # Sets Cloudflare LB cookie for backend pinning — best-effort
+def get_page():
+    """Get the browser page for use by Client.request()."""
+    return _page
+
+
+def get_csrf():
+    """Get the CSRF token for use by Client.request()."""
+    return _csrf
+
+
+def close() -> None:
+    """Close the browser. Call when done."""
+    global _cm, _browser, _page, _csrf
+    if _cm:
+        try:
+            _cm.__exit__(None, None, None)
+        except Exception as e:
+            log.debug("Error closing browser context manager: %s", e)
+    _cm = None
+    _browser = None
+    _page = None
+    _csrf = None
+
+
+# --- Internal helpers ---
+
+
+def _try_setup() -> bool:
+    """Extract CSRF token and verify session is valid."""
+    global _csrf
+    current = _page.url
+    if "/modern/" not in current:
+        try:
+            _page.goto(
+                "https://connect.garmin.com/modern/",
+                wait_until="domcontentloaded",
+            )
+        except Exception as e:
+            log.debug("Navigation to /modern/ failed: %s", e)
+        time.sleep(3)
+
     try:
-        client.get(
-            "sso",
-            "/portal/sso/embed",
-            headers={**SSO_PAGE_HEADERS, "Sec-Fetch-Site": "same-origin"},
-            referrer=True,
-        )
-    except GarthException:  # pragma: no cover
-        pass
+        setup = _page.evaluate("""
+            async () => {
+                const csrf = document.querySelector(
+                    'meta[name="csrf-token"], meta[name="_csrf"]'
+                )?.content;
+                const h = {'connect-csrf-token': csrf};
+                const resp = await fetch(
+                    '/gc-api/userprofile-service/socialProfile',
+                    {credentials: 'include', headers: h}
+                );
+                const profile = resp.status === 200
+                    ? await resp.json() : null;
+                return {
+                    csrf,
+                    displayName: profile?.displayName,
+                };
+            }
+        """)
+        _csrf = setup.get("csrf")
+        return bool(_csrf)
+    except Exception as e:
+        log.debug("CSRF extraction failed: %s", e)
+        return False
 
-    oauth1 = get_oauth1_token(ticket, client)
-    oauth2 = exchange(oauth1, client, login=True)
-    return oauth1, oauth2
+
+def _do_login(
+    email: str,
+    password: str,
+    prompt_mfa: Callable | None,
+    domain: str = "garmin.com",
+) -> None:
+    """Perform SSO login via browser."""
+    global _page, _csrf
+
+    # Build SSO URL from domain config (supports garmin.cn)
+    sso_domain = "sso.garmin.com"
+    connect_domain = "connect.garmin.com"
+    if domain == "garmin.cn":
+        sso_domain = "sso.garmin.cn"
+        connect_domain = "connect.garmin.cn"
+
+    sso_url = (
+        f"https://{sso_domain}/portal/sso/en-US/sign-in"
+        f"?clientId=GarminConnect"
+        f"&service=https%3A%2F%2F{connect_domain}%2Fapp"
+    )
+
+    try:
+        _page.goto(
+            sso_url, wait_until="domcontentloaded", timeout=30000
+        )
+    except Exception as e:
+        log.debug("SSO page navigation error: %s", e)
+    time.sleep(3)
+
+    # Fill login form
+    email_input = _page.locator('input[name="email"]').first
+    email_input.wait_for(timeout=15000)
+    email_input.click()
+    _page.keyboard.type(email, delay=30)
+
+    _page.locator('input[name="password"]').first.click()
+    _page.keyboard.type(password, delay=30)
+
+    try:
+        _page.evaluate(
+            "() => { const cb = document.querySelector("
+            '"input[name=remember]"); '
+            "if (cb && !cb.checked) cb.click(); }"
+        )
+    except Exception as e:
+        log.debug("Remember-me checkbox not found: %s", e)
+
+    _page.locator('button[type="submit"]').first.click()
+
+    # Wait for redirect or MFA
+    for _ in range(120):
+        time.sleep(1)
+        url = _page.url
+
+        if (
+            connect_domain in url
+            and sso_domain not in url
+        ):
+            break
+
+        # Check tabs (some redirects open new tabs)
+        for p in _page.context.pages:
+            if (
+                connect_domain in p.url
+                and sso_domain not in p.url
+            ):
+                _page = p
+                break
+        if (
+            connect_domain in _page.url
+            and sso_domain not in _page.url
+        ):
+            break
+
+        # MFA detection
+        has_mfa = _page.evaluate(
+            "() => document.querySelector("
+            '"input[name=securityCode]") !== null'
+        )
+        if has_mfa:
+            mfa_func = prompt_mfa or input
+            code = mfa_func().strip()
+
+            _page.locator(
+                'input[name="securityCode"]'
+            ).first.fill(code)
+            try:
+                _page.evaluate(
+                    "() => { const cb = document.querySelector("
+                    '"input[name=remember]"); '
+                    "if (cb && !cb.checked) cb.click(); }"
+                )
+            except Exception as e:
+                log.debug("MFA remember checkbox not found: %s", e)
+            _page.locator('button:has-text("Next")').first.click()
+
+            # Wait for redirect after MFA
+            for _ in range(60):
+                time.sleep(1)
+                if (
+                    connect_domain in _page.url
+                    and sso_domain not in _page.url
+                ):
+                    break
+                try:
+                    has_app = _page.evaluate(
+                        "() => document.body?.innerText"
+                        '?.includes("Activities")'
+                    )
+                    if has_app:
+                        _page.goto(
+                            f"https://{connect_domain}/modern/",
+                            wait_until="domcontentloaded",
+                        )
+                        time.sleep(2)
+                        break
+                except Exception as e:
+                    log.debug("Post-MFA check failed: %s", e)
+            break
+
+    time.sleep(3)
+
+    if sso_domain in _page.url:
+        raise GarthException(
+            msg="Login failed — still on SSO page"
+        )
+
+    if not _try_setup():
+        raise GarthException(
+            msg="Login succeeded but could not extract session data"
+        )
+
+
+def _save_session(session_file: Path) -> None:
+    """Save browser cookies for session persistence."""
+    try:
+        cookies = _page.context.cookies()
+        garmin_cookies = [
+            c for c in cookies if "garmin" in c.get("domain", "")
+        ]
+        session = {
+            "cookies": garmin_cookies,
+            "saved_at": time.time(),
+        }
+        fd = os.open(
+            str(session_file),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        with os.fdopen(fd, "w") as f:
+            json.dump(session, f, indent=2)
+    except Exception as e:
+        log.warning("Could not save session cookies: %s", e)

--- a/src/garth/telemetry.py
+++ b/src/garth/telemetry.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from requests import Response, Session
 
 from .version import __version__
 
@@ -112,17 +111,18 @@ class Telemetry(BaseSettings):
     enabled: bool = False
     send_to_logfire: bool = False
     token: str = DEFAULT_TOKEN
-    callback: Callable[[dict], None] | None = Field(default=None, exclude=True)
+    callback: Callable[[dict], None] | None = Field(
+        default=None, exclude=True
+    )
     session_id: str = Field(
         default_factory=lambda: uuid.uuid4().hex[:16],
         exclude=True,
     )
     _logfire_configured: bool = False
     _logfire_instance: Any = None
-    _attached_sessions: set = set()
 
     def model_post_init(self, __context):
-        self._attached_sessions = set()
+        pass
 
     def _default_callback(self, data: dict):
         """Default callback that sends to logfire."""
@@ -132,42 +132,6 @@ class Telemetry(BaseSettings):
             "http {method} {url} {status_code}", **data
         )
 
-    def _response_hook(self, response: Response, *args, **kwargs):
-        """Session hook that captures request/response data."""
-        if not self.enabled:
-            return
-
-        try:
-            request = response.request
-            if request is None:  # pragma: no cover
-                return
-            data = {
-                "session_id": self.session_id,
-                "garth_version": __version__,
-                "method": request.method,
-                "url": request.url,
-                "status_code": response.status_code,
-                "request_headers": str(
-                    sanitize_headers(dict(request.headers))
-                ),
-                "response_headers": str(
-                    sanitize_headers(dict(response.headers))
-                ),
-            }
-
-            if request.body:
-                body = request.body
-                if isinstance(body, bytes):
-                    body = body.decode("utf-8", errors="replace")
-                data["request_body"] = sanitize(body)
-
-            data["response_body"] = sanitize(response.text)
-
-            callback = self.callback or self._default_callback
-            callback(data)
-        except Exception:
-            pass  # Don't let telemetry errors break the app
-
     def configure(
         self,
         enabled: bool | None = None,
@@ -175,17 +139,6 @@ class Telemetry(BaseSettings):
         token: str | None = None,
         callback: Callable[[dict], None] | None = None,
     ):
-        """
-        Configure telemetry. Disabled by default.
-
-        Args:
-            enabled: Enable/disable telemetry (default: False)
-            send_to_logfire: Send to Logfire Cloud (default: False)
-            token: Logfire write token
-            callback: Custom callback for telemetry data. If provided,
-                logfire will not be configured and data will be passed
-                to this callback instead.
-        """
         if enabled is not None:
             self.enabled = enabled
         if send_to_logfire is not None:
@@ -198,16 +151,10 @@ class Telemetry(BaseSettings):
         if not self.enabled:
             return
 
-        # Configure logfire only if using default callback and not yet done
         if self.callback is None and not self._logfire_configured:
             self._configure_logfire()
 
     def _configure_logfire(self):
-        """Configure a local logfire instance for garth telemetry.
-
-        Uses local=True to avoid overwriting logfire configuration
-        in applications that integrate garth.
-        """
         if not LOGFIRE_AVAILABLE:
             return
 
@@ -216,20 +163,9 @@ class Telemetry(BaseSettings):
             service_name="garth",
             send_to_logfire=self.send_to_logfire,
             token=self.token,
-            scrubbing=logfire.ScrubbingOptions(callback=_scrubbing_callback),
+            scrubbing=logfire.ScrubbingOptions(
+                callback=_scrubbing_callback
+            ),
             console=False,
         )
         self._logfire_configured = True
-
-    def attach(self, session: Session):
-        """Attach telemetry hooks to a session.
-
-        This method is idempotent - calling it multiple times with the
-        same session will only attach the hook once.
-        """
-        session_id = id(session)
-        if session_id in self._attached_sessions:
-            return
-
-        session.hooks["response"].append(self._response_hook)
-        self._attached_sessions.add(session_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,13 +110,15 @@ def _make_cassette_replayer(interactions):
         /,
         api=False,
         referrer=False,
-        headers={},
+        headers=None,
         **kwargs,
     ):
+        if headers is None:
+            headers = {}
         match_path = path.lstrip("/")
         params = kwargs.get("params")
         if params:
-            match_path += "?" + urlencode(params)
+            match_path += "?" + urlencode(params, doseq=True)
 
         with lock:
             best_idx = None
@@ -132,12 +134,16 @@ def _make_cassette_replayer(interactions):
                     best_idx = i
                     break
 
-            if best_idx is None and remaining:
-                best_idx = 0
-
             if best_idx is None:
+                expected = f"{method.upper()} {match_path}"
+                available = [
+                    f"{r['request'].get('method', 'GET')} "
+                    f"{r['request'].get('uri', '')}"
+                    for r in remaining
+                ]
                 raise RuntimeError(
-                    "No cassette interactions remaining"
+                    f"No cassette match for {expected}. "
+                    f"Available: {available}"
                 )
 
             interaction = remaining.pop(best_idx)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,29 @@
 import gzip
 import io
 import os
+import threading
 import time
-
-
-# Disable telemetry before importing garth — the module-level
-# Client() in http.py runs at import time and would configure logfire
-os.environ["GARTH_TELEMETRY_ENABLED"] = "false"
+import types
+from urllib.parse import urlencode
 
 import pytest
-from requests import Session
+import yaml
 
 from garth.auth_tokens import OAuth1Token, OAuth2Token
-from garth.http import Client
+from garth.http import Client, _Response
 from garth.telemetry import REDACTED, sanitize, sanitize_cookie
+
+
+# Disable telemetry before tests
+os.environ["GARTH_TELEMETRY_ENABLED"] = "false"
+
+
+def pytest_configure(config):
+    """Register the vcr marker so tests don't emit warnings."""
+    config.addinivalue_line(
+        "markers",
+        "vcr: replay API responses from cassette YAML files",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -25,16 +35,10 @@ def _clean_env(monkeypatch):
 
 
 @pytest.fixture
-def session():
-    return Session()
-
-
-@pytest.fixture
-def client(session, monkeypatch) -> Client:
-    # Clear env vars to prevent auto-resume in tests
+def client(monkeypatch) -> Client:
     monkeypatch.delenv("GARTH_HOME", raising=False)
     monkeypatch.delenv("GARTH_TOKEN", raising=False)
-    return Client(session=session)
+    return Client()
 
 
 @pytest.fixture
@@ -68,90 +72,136 @@ def oauth2_token_dict() -> dict:
 
 @pytest.fixture
 def oauth2_token(oauth2_token_dict: dict) -> OAuth2Token:
-    token = OAuth2Token(
+    return OAuth2Token(
         expires_at=int(time.time() + 3599),
         refresh_token_expires_at=int(time.time() + 7199),
         **oauth2_token_dict,
     )
-    return token
+
+
+# --- Cassette replay infrastructure ---
+
+
+def _load_cassette_interactions(cassette_dir, test_name):
+    """Load interactions from a VCR cassette YAML file."""
+    yaml_path = os.path.join(cassette_dir, f"{test_name}.yaml")
+    if not os.path.exists(yaml_path):
+        return None
+    with open(yaml_path) as f:
+        cassette = yaml.safe_load(f)
+    return cassette.get("interactions", [])
+
+
+def _make_cassette_replayer(interactions):
+    """Create a request() method that replays cassette responses.
+
+    Matches by URL path and method. For duplicate URLs, serves
+    in order. Thread-safe for parallel calls from
+    ThreadPoolExecutor.
+    """
+    remaining = list(interactions)
+    lock = threading.Lock()
+
+    def mock_request(
+        self,
+        method,
+        subdomain,
+        path,
+        /,
+        api=False,
+        referrer=False,
+        headers={},
+        **kwargs,
+    ):
+        match_path = path.lstrip("/")
+        params = kwargs.get("params")
+        if params:
+            match_path += "?" + urlencode(params)
+
+        with lock:
+            best_idx = None
+            for i, interaction in enumerate(remaining):
+                req = interaction["request"]
+                cassette_uri = req.get("uri", "")
+                cassette_method = req.get("method", "GET")
+
+                if (
+                    method.upper() == cassette_method.upper()
+                    and match_path in cassette_uri
+                ):
+                    best_idx = i
+                    break
+
+            if best_idx is None and remaining:
+                best_idx = 0
+
+            if best_idx is None:
+                raise RuntimeError(
+                    "No cassette interactions remaining"
+                )
+
+            interaction = remaining.pop(best_idx)
+
+        resp_data = interaction["response"]
+        status = resp_data.get("status", {}).get("code", 200)
+        body = resp_data.get("body", {}).get("string", "")
+        if isinstance(body, bytes):
+            try:
+                body = gzip.GzipFile(
+                    fileobj=io.BytesIO(body)
+                ).read().decode("utf-8")
+            except (gzip.BadGzipFile, OSError):
+                body = body.decode("utf-8", errors="replace")
+        uri = interaction["request"].get("uri", "")
+
+        resp = _Response(status, body, uri)
+        self.last_resp = resp
+
+        if not resp.ok:
+            resp.raise_for_status()
+
+        return resp
+
+    return mock_request
+
+
+def _find_cassette_dir(test_file):
+    """Find the cassette directory relative to a test file."""
+    test_dir = os.path.dirname(str(test_file))
+    cassette_dir = os.path.join(test_dir, "cassettes")
+    if os.path.isdir(cassette_dir):
+        return cassette_dir
+    return None
 
 
 @pytest.fixture
 def authed_client(
-    oauth1_token: OAuth1Token, oauth2_token: OAuth2Token
+    request,
+    oauth1_token: OAuth1Token,
+    oauth2_token: OAuth2Token,
 ) -> Client:
-    client = Client()
-    recording = os.environ.get("GARTH_RECORD_CASSETTES") == "true"
-    garth_home = os.environ.get("GARTH_RECORD_CASSETTES_HOME")
-    if recording and garth_home:  # pragma: no cover
-        client.load(garth_home)
-    else:
-        client.configure(oauth1_token=oauth1_token, oauth2_token=oauth2_token)
-    client._garth_home = None
-    assert client.oauth2_token and isinstance(client.oauth2_token, OAuth2Token)
-    assert not client.oauth2_token.expired
-    return client
+    """Client with tokens and cassette replay for vcr tests."""
+    c = Client()
+    c.configure(
+        oauth1_token=oauth1_token, oauth2_token=oauth2_token
+    )
+    c._garth_home = None
+    assert c.oauth2_token and isinstance(
+        c.oauth2_token, OAuth2Token
+    )
+    assert not c.oauth2_token.expired
 
+    marker = request.node.get_closest_marker("vcr")
+    if marker:
+        cassette_dir = _find_cassette_dir(request.fspath)
+        if cassette_dir:
+            test_name = request.node.name
+            interactions = _load_cassette_interactions(
+                cassette_dir, test_name
+            )
+            if interactions:
+                c.request = types.MethodType(
+                    _make_cassette_replayer(interactions), c
+                )
 
-@pytest.fixture
-def vcr(vcr):
-    if os.environ.get("GARTH_RECORD_CASSETTES") != "true":
-        vcr.record_mode = "none"
-    return vcr
-
-
-def sanitize_request(request):
-    if request.body:
-        try:
-            body = request.body.decode("utf8")
-        except UnicodeDecodeError:
-            ...
-        else:
-            request.body = sanitize(body).encode("utf8")
-
-    if "Cookie" in request.headers:
-        cookies = request.headers["Cookie"].split("; ")
-        sanitized_cookies = [sanitize_cookie(cookie) for cookie in cookies]
-        request.headers["Cookie"] = "; ".join(sanitized_cookies)
-    return request
-
-
-def sanitize_response(response):
-    try:
-        encoding = response["headers"].pop("Content-Encoding")
-    except KeyError:
-        ...
-    else:
-        if encoding[0] == "gzip":
-            body = response["body"]["string"]
-            buffer = io.BytesIO(body)
-            try:
-                body = gzip.GzipFile(fileobj=buffer).read()
-            except gzip.BadGzipFile:  # pragma: no cover
-                ...
-            else:
-                response["body"]["string"] = body
-
-    for key in ["set-cookie", "Set-Cookie"]:
-        if key in response["headers"]:
-            cookies = response["headers"][key]
-            sanitized_cookies = [sanitize_cookie(cookie) for cookie in cookies]
-            response["headers"][key] = sanitized_cookies
-
-    try:
-        body = response["body"]["string"].decode("utf8")
-    except UnicodeDecodeError:
-        pass
-    else:
-        response["body"]["string"] = sanitize(body).encode("utf8")
-
-    return response
-
-
-@pytest.fixture(scope="session")
-def vcr_config():
-    return {
-        "filter_headers": [("Authorization", f"Bearer {REDACTED}")],
-        "before_record_request": sanitize_request,
-        "before_record_response": sanitize_response,
-    }
+    return c

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,14 +1,15 @@
 import builtins
 import getpass
 import sys
+import time
 
 import pytest
 
+from garth.auth_tokens import OAuth1Token, OAuth2Token
 from garth.cli import main
 
 
 def test_help_flag(monkeypatch, capsys):
-    # -h should print help and exit with code 0
     monkeypatch.setattr(sys, "argv", ["garth", "-h"])
     with pytest.raises(SystemExit) as excinfo:
         main()
@@ -18,27 +19,44 @@ def test_help_flag(monkeypatch, capsys):
 
 
 def test_no_args_prints_help(monkeypatch, capsys):
-    # No args should print help and not exit
     monkeypatch.setattr(sys, "argv", ["garth"])
     main()
     out, err = capsys.readouterr()
     assert "usage:" in out.lower()
 
 
-@pytest.mark.vcr
 def test_login_command(monkeypatch, capsys):
+    mock_oauth1 = OAuth1Token(
+        oauth_token="test_token",
+        oauth_token_secret="test_secret",
+        domain="garmin.com",
+    )
+    mock_oauth2 = OAuth2Token(
+        scope="CONNECT_READ",
+        jti="test_jti",
+        token_type="Bearer",
+        access_token="test_access",
+        refresh_token="test_refresh",
+        expires_in=3600,
+        refresh_token_expires_in=7200,
+        expires_at=int(time.time() + 3600),
+        refresh_token_expires_at=int(time.time() + 7200),
+    )
+
+    import garth.sso
+    monkeypatch.setattr(
+        garth.sso, "login", lambda *a, **kw: (mock_oauth1, mock_oauth2)
+    )
+
     def mock_input(prompt):
-        match prompt:
-            case "Email: ":
-                return "user@example.com"
-            case "MFA code: ":
-                code = "023226"
-                return code
+        if "Email" in prompt:
+            return "user@example.com"
+        return ""
 
     monkeypatch.setattr(sys, "argv", ["garth", "login"])
     monkeypatch.setattr(builtins, "input", mock_input)
     monkeypatch.setattr(getpass, "getpass", lambda _: "correct_password")
     main()
     out, err = capsys.readouterr()
-    assert out
+    assert out  # Should print base64 token
     assert not err

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -356,13 +356,14 @@ def test_auto_persist_on_refresh(
 
         import os
         oauth1_path = os.path.join(tempdir, "oauth1_token.json")
-        oauth1_mtime_before = os.path.getmtime(oauth1_path)
-        time.sleep(0.01)
+        with open(oauth1_path) as f:
+            oauth1_content_before = f.read()
 
         client.refresh_oauth2()
 
-        oauth1_mtime_after = os.path.getmtime(oauth1_path)
-        assert oauth1_mtime_before == oauth1_mtime_after
+        with open(oauth1_path) as f:
+            oauth1_content_after = f.read()
+        assert oauth1_content_before == oauth1_content_after
 
         fresh_client = Client()
         fresh_client.load(tempdir)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -3,11 +3,11 @@ import time
 from typing import Any, cast
 
 import pytest
-from requests.adapters import HTTPAdapter
 
+from garth import sso
 from garth.auth_tokens import OAuth1Token, OAuth2Token
 from garth.exc import GarthException, GarthHTTPError
-from garth.http import Client
+from garth.http import Client, _Response
 
 
 def test_dump_and_load(authed_client: Client):
@@ -67,9 +67,214 @@ def test_auto_resume_garth_home_missing_tokens(
         assert client.oauth2_token is None
 
 
+def test_auto_resume_both_set_raises(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("GARTH_HOME", "/some/path")
+    monkeypatch.setenv("GARTH_TOKEN", "some_token")
+
+    with pytest.raises(GarthException, match="cannot both be set"):
+        Client()
+
+
+def test_load_browser_tokens_warns(caplog):
+    """Loading browser-backed tokens should warn the user."""
+    browser_oauth1 = OAuth1Token(
+        oauth_token=sso.BROWSER_TOKEN_SENTINEL,
+        oauth_token_secret=sso.BROWSER_TOKEN_SENTINEL,
+        domain="garmin.com",
+    )
+    browser_oauth2 = sso._placeholder_oauth2()
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        # Save browser tokens
+        client = Client()
+        client.configure(
+            oauth1_token=browser_oauth1,
+            oauth2_token=browser_oauth2,
+        )
+        client.dump(tempdir)
+
+        # Load them back — should warn
+        import logging
+        with caplog.at_level(logging.WARNING, logger="garth.http"):
+            new_client = Client()
+            new_client.load(tempdir)
+
+        assert "browser-session" in caplog.text
+        assert "call login()" in caplog.text
+
+
+def test_loads_browser_tokens_warns(caplog):
+    """Loading browser-backed tokens from string should warn."""
+    browser_oauth1 = OAuth1Token(
+        oauth_token=sso.BROWSER_TOKEN_SENTINEL,
+        oauth_token_secret=sso.BROWSER_TOKEN_SENTINEL,
+        domain="garmin.com",
+    )
+    browser_oauth2 = sso._placeholder_oauth2()
+
+    client = Client()
+    client.configure(
+        oauth1_token=browser_oauth1,
+        oauth2_token=browser_oauth2,
+    )
+    token_str = client.dumps()
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="garth.http"):
+        new_client = Client()
+        new_client.loads(token_str)
+
+    assert "browser-session" in caplog.text
+
+
+def test_configure_oauth2_token(
+    client: Client, oauth2_token: OAuth2Token
+):
+    assert client.oauth2_token is None
+    client.configure(oauth2_token=oauth2_token)
+    assert client.oauth2_token == oauth2_token
+
+
+def test_configure_domain(client: Client):
+    assert client.domain == "garmin.com"
+    client.configure(domain="garmin.cn")
+    assert client.domain == "garmin.cn"
+
+
+def test_configure_timeout(client: Client):
+    assert client.timeout == 10
+    client.configure(timeout=99)
+    assert client.timeout == 99
+
+
+def test_configure_retry(client: Client):
+    assert client.retries == 3
+    client.configure(retries=99)
+    assert client.retries == 99
+
+
+def test_configure_proxies_warns(client: Client, caplog):
+    """Proxies should emit a warning with browser transport."""
+    import logging
+    with caplog.at_level(logging.WARNING, logger="garth.http"):
+        client.configure(proxies={"https": "http://localhost"})
+    assert "proxies" in caplog.text
+
+
+def test_configure_ssl_verify_warns(client: Client, caplog):
+    """ssl_verify should emit a warning with browser transport."""
+    import logging
+    with caplog.at_level(logging.WARNING, logger="garth.http"):
+        client.configure(ssl_verify=False)
+    assert "ssl_verify" in caplog.text
+
+
+def test_request_requires_login(client: Client):
+    with pytest.raises(GarthException, match="Not logged in"):
+        client.request("GET", "connectapi", "/test-path")
+
+
+def test_response_class():
+    resp = _Response(200, '{"key": "value"}', "https://example.com")
+    assert resp.ok
+    assert resp.status_code == 200
+    assert resp.json() == {"key": "value"}
+    assert resp.content == b'{"key": "value"}'
+    resp.raise_for_status()
+
+
+def test_response_error():
+    resp = _Response(403, "Forbidden", "https://example.com")
+    assert not resp.ok
+    with pytest.raises(GarthHTTPError, match="403"):
+        resp.raise_for_status()
+
+
+@pytest.mark.vcr
+def test_connectapi(authed_client: Client):
+    stress = cast(
+        list[dict[str, Any]],
+        authed_client.connectapi(
+            "/usersummary-service/stats/stress/daily/"
+            "2023-07-21/2023-07-21"
+        ),
+    )
+    assert stress
+    assert isinstance(stress, list)
+    assert len(stress) == 1
+    assert stress[0]["calendarDate"] == "2023-07-21"
+    assert list(stress[0]["values"].keys()) == [
+        "highStressDuration",
+        "lowStressDuration",
+        "overallStressLevel",
+        "restStressDuration",
+        "mediumStressDuration",
+    ]
+
+
+@pytest.mark.vcr
+def test_username(authed_client: Client):
+    assert authed_client._user_profile is None
+    assert authed_client.username
+    assert authed_client._user_profile
+
+
+@pytest.mark.vcr
+def test_profile_alias(authed_client: Client):
+    assert authed_client._user_profile is None
+    profile = authed_client.profile
+    assert profile == authed_client.user_profile
+    assert authed_client._user_profile is not None
+
+
+def test_download(authed_client: Client, monkeypatch):
+    """Download returns bytes via browser fetch."""
+    class MockPage:
+        def evaluate(self, js, args):
+            import base64
+            data = base64.b64encode(
+                b"\x50\x4b\x03\x04test"
+            ).decode()
+            return {"status": 200, "data": data}
+
+    monkeypatch.setattr(sso, "get_page", lambda: MockPage())
+    monkeypatch.setattr(sso, "get_csrf", lambda: "test_csrf")
+
+    result = authed_client.download(
+        "/download-service/files/activity/11998957007"
+    )
+    assert result
+    assert isinstance(result, bytes)
+    assert result[:4] == b"\x50\x4b\x03\x04"
+
+
+def test_upload_rejects_multiple_files(
+    authed_client: Client, monkeypatch
+):
+    """Upload should reject multiple files."""
+    class MockPage:
+        def evaluate(self, js, args):
+            return {"status": 200, "text": "{}", "url": ""}
+
+    monkeypatch.setattr(sso, "get_page", lambda: MockPage())
+    monkeypatch.setattr(sso, "get_csrf", lambda: "test_csrf")
+
+    import io
+    files = {
+        "file1": ("a.fit", io.BytesIO(b"data1")),
+        "file2": ("b.fit", io.BytesIO(b"data2")),
+    }
+    with pytest.raises(GarthException, match="single file"):
+        authed_client.request(
+            "POST", "connectapi", "/upload", files=files
+        )
+
+
 @pytest.fixture
 def garth_home_client(monkeypatch: pytest.MonkeyPatch):
-    """Client with GARTH_HOME set to a temp dir and mock tokens."""
+    """Client with GARTH_HOME set to a temp dir."""
     import garth.sso
 
     with tempfile.TemporaryDirectory() as tempdir:
@@ -93,7 +298,9 @@ def garth_home_client(monkeypatch: pytest.MonkeyPatch):
             expires_at=int(time.time() + 3600),
             refresh_token_expires_at=int(time.time() + 7200),
         )
-        yield client, tempdir, mock_oauth1, mock_oauth2, garth.sso
+        yield (
+            client, tempdir, mock_oauth1, mock_oauth2, garth.sso
+        )
 
 
 def _assert_tokens_saved(tempdir, mock_oauth1, mock_oauth2):
@@ -104,49 +311,30 @@ def _assert_tokens_saved(tempdir, mock_oauth1, mock_oauth2):
 
 
 def test_auto_save_on_login(garth_home_client, monkeypatch):
-    client, tempdir, mock_oauth1, mock_oauth2, sso_mod = garth_home_client
+    client, tempdir, mock_oauth1, mock_oauth2, sso_mod = (
+        garth_home_client
+    )
     monkeypatch.setattr(
-        sso_mod, "login", lambda *a, **kw: (mock_oauth1, mock_oauth2)
+        sso_mod,
+        "login",
+        lambda *a, **kw: (mock_oauth1, mock_oauth2),
     )
 
     client.login("user@example.com", "password")
     _assert_tokens_saved(tempdir, mock_oauth1, mock_oauth2)
 
 
-def test_auto_save_on_resume_login(garth_home_client, monkeypatch):
-    client, tempdir, mock_oauth1, mock_oauth2, sso_mod = garth_home_client
-    monkeypatch.setattr(
-        sso_mod,
-        "resume_login",
-        lambda *a, **kw: (mock_oauth1, mock_oauth2),
-    )
-
-    client.resume_login({"client": client, "login_params": {}}, "123")
-    _assert_tokens_saved(tempdir, mock_oauth1, mock_oauth2)
-
-
-def test_auto_resume_both_set_raises(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("GARTH_HOME", "/some/path")
-    monkeypatch.setenv("GARTH_TOKEN", "some_token")
-
-    with pytest.raises(GarthException, match="cannot both be set"):
-        Client()
-
-
 def test_auto_persist_on_refresh(
     authed_client: Client, monkeypatch: pytest.MonkeyPatch
 ):
     with tempfile.TemporaryDirectory() as tempdir:
-        # Save initial tokens
         authed_client.dump(tempdir)
         monkeypatch.setenv("GARTH_HOME", tempdir)
         monkeypatch.delenv("GARTH_TOKEN", raising=False)
 
-        # Create client that auto-resumes from GARTH_HOME
         client = Client()
         assert client._garth_home == tempdir
 
-        # Create a new token with different expiration
         new_oauth2 = OAuth2Token(
             scope="CONNECT_READ CONNECT_WRITE",
             jti="new_jti",
@@ -159,279 +347,23 @@ def test_auto_persist_on_refresh(
             refresh_token_expires_at=int(time.time() + 14400),
         )
 
-        # Mock sso.exchange to return the new token
         import garth.sso
-
         monkeypatch.setattr(
-            garth.sso, "exchange", lambda *args, **kwargs: new_oauth2
+            garth.sso,
+            "exchange",
+            lambda *args, **kwargs: new_oauth2,
         )
 
-        # Get oauth1 file modification time before refresh
         import os
-
         oauth1_path = os.path.join(tempdir, "oauth1_token.json")
         oauth1_mtime_before = os.path.getmtime(oauth1_path)
-
-        # Small delay to ensure mtime would change if file is written
         time.sleep(0.01)
 
-        # Trigger refresh
         client.refresh_oauth2()
 
-        # Verify oauth1 file was NOT updated (oauth2_only=True)
         oauth1_mtime_after = os.path.getmtime(oauth1_path)
         assert oauth1_mtime_before == oauth1_mtime_after
 
-        # Verify the new token was persisted to GARTH_HOME
         fresh_client = Client()
         fresh_client.load(tempdir)
         assert fresh_client.oauth2_token == new_oauth2
-
-
-def test_configure_oauth2_token(client: Client, oauth2_token: OAuth2Token):
-    assert client.oauth2_token is None
-    client.configure(oauth2_token=oauth2_token)
-    assert client.oauth2_token == oauth2_token
-
-
-def test_configure_domain(client: Client):
-    assert client.domain == "garmin.com"
-    client.configure(domain="garmin.cn")
-    assert client.domain == "garmin.cn"
-
-
-def test_configure_proxies(client: Client):
-    assert client.sess.proxies == {}
-    proxy = {"https": "http://localhost:8888"}
-    client.configure(proxies=proxy)
-    assert client.sess.proxies["https"] == proxy["https"]
-
-
-def test_configure_ssl_verify(client: Client):
-    assert client.sess.verify is True
-    client.configure(ssl_verify=False)
-    assert client.sess.verify is False
-
-
-def test_configure_timeout(client: Client):
-    assert client.timeout == 10
-    client.configure(timeout=99)
-    assert client.timeout == 99
-
-
-def test_configure_retry(client: Client):
-    assert client.retries == 3
-    adapter = client.sess.adapters["https://"]
-    assert isinstance(adapter, HTTPAdapter)
-    assert adapter.max_retries.total == client.retries
-
-    client.configure(retries=99)
-    assert client.retries == 99
-    adapter = client.sess.adapters["https://"]
-    assert isinstance(adapter, HTTPAdapter)
-    assert adapter.max_retries.total == 99
-
-
-def test_configure_status_forcelist(client: Client):
-    assert client.status_forcelist == (408, 500, 502, 503, 504)
-    adapter = client.sess.adapters["https://"]
-    assert isinstance(adapter, HTTPAdapter)
-    assert adapter.max_retries.status_forcelist == client.status_forcelist
-
-    client.configure(status_forcelist=(200, 201, 202))
-    assert client.status_forcelist == (200, 201, 202)
-    adapter = client.sess.adapters["https://"]
-    assert isinstance(adapter, HTTPAdapter)
-    assert adapter.max_retries.status_forcelist == client.status_forcelist
-
-
-def test_configure_backoff_factor(client: Client):
-    assert client.backoff_factor == 0.5
-    adapter = client.sess.adapters["https://"]
-    assert isinstance(adapter, HTTPAdapter)
-    assert adapter.max_retries.backoff_factor == client.backoff_factor
-
-    client.configure(backoff_factor=0.99)
-    assert client.backoff_factor == 0.99
-    adapter = client.sess.adapters["https://"]
-    assert isinstance(adapter, HTTPAdapter)
-    assert adapter.max_retries.backoff_factor == client.backoff_factor
-
-
-def test_configure_pool_maxsize(client: Client):
-    assert client.pool_maxsize == 10
-    client.configure(pool_maxsize=99)
-    assert client.pool_maxsize == 99
-    adapter = client.sess.adapters["https://"]
-    assert isinstance(adapter, HTTPAdapter)
-    assert adapter.poolmanager.connection_pool_kw["maxsize"] == 99
-
-
-def test_configure_pool_connections(client: Client):
-    client.configure(pool_connections=99)
-    assert client.pool_connections == 99
-    adapter = client.sess.adapters["https://"]
-    assert isinstance(adapter, HTTPAdapter)
-    assert getattr(adapter, "_pool_connections", None) == 99, (
-        "Pool connections not properly configured"
-    )
-
-
-@pytest.mark.vcr
-def test_client_request(client: Client):
-    resp = client.request("GET", "connect", "/")
-    assert resp.ok
-
-    with pytest.raises(GarthHTTPError) as e:
-        client.request("GET", "connectapi", "/")
-    assert "404" in str(e.value)
-
-
-@pytest.mark.vcr
-def test_login_success_mfa(monkeypatch, client: Client):
-    def mock_input(_):
-        return "327751"
-
-    monkeypatch.setattr("builtins.input", mock_input)
-
-    assert client.oauth1_token is None
-    assert client.oauth2_token is None
-    client.login("user@example.com", "correct_password")
-    assert client.oauth1_token
-    assert client.oauth2_token
-
-
-@pytest.mark.vcr
-def test_username(authed_client: Client):
-    assert authed_client._user_profile is None
-    assert authed_client.username
-    assert authed_client._user_profile
-
-
-@pytest.mark.vcr
-def test_profile_alias(authed_client: Client):
-    assert authed_client._user_profile is None
-    profile = authed_client.profile
-    assert profile == authed_client.user_profile
-    assert authed_client._user_profile is not None
-
-
-@pytest.mark.vcr
-def test_connectapi(authed_client: Client):
-    stress = cast(
-        list[dict[str, Any]],
-        authed_client.connectapi(
-            "/usersummary-service/stats/stress/daily/2023-07-21/2023-07-21"
-        ),
-    )
-    assert stress
-    assert isinstance(stress, list)
-    assert len(stress) == 1
-    assert stress[0]["calendarDate"] == "2023-07-21"
-    assert list(stress[0]["values"].keys()) == [
-        "highStressDuration",
-        "lowStressDuration",
-        "overallStressLevel",
-        "restStressDuration",
-        "mediumStressDuration",
-    ]
-
-
-@pytest.mark.vcr
-def test_refresh_oauth2_token(authed_client: Client):
-    assert authed_client.oauth2_token and isinstance(
-        authed_client.oauth2_token, OAuth2Token
-    )
-    authed_client.oauth2_token.expires_at = int(time.time())
-    assert authed_client.oauth2_token.expired
-    profile = authed_client.connectapi("/userprofile-service/socialProfile")
-    assert profile
-    assert isinstance(profile, dict)
-    assert profile["userName"]
-
-
-@pytest.mark.vcr
-def test_download(authed_client: Client):
-    downloaded = authed_client.download(
-        "/download-service/files/activity/11998957007"
-    )
-    assert downloaded
-    zip_magic_number = b"\x50\x4b\x03\x04"
-    assert downloaded[:4] == zip_magic_number
-
-
-@pytest.mark.vcr
-def test_upload(authed_client: Client):
-    fpath = "tests/12129115726_ACTIVITY.fit"
-    with open(fpath, "rb") as f:
-        uploaded = authed_client.upload(f)
-    assert uploaded
-
-
-@pytest.mark.vcr
-def test_delete(authed_client: Client):
-    activity_id = "12135235656"
-    path = f"/activity-service/activity/{activity_id}"
-    assert authed_client.connectapi(path)
-    authed_client.delete(
-        "connectapi",
-        path,
-        api=True,
-    )
-    with pytest.raises(GarthHTTPError) as e:
-        authed_client.connectapi(path)
-    assert "404" in str(e.value)
-
-
-@pytest.mark.vcr
-def test_put(authed_client: Client):
-    data = [
-        {
-            "changeState": "CHANGED",
-            "trainingMethod": "HR_RESERVE",
-            "lactateThresholdHeartRateUsed": 170,
-            "maxHeartRateUsed": 185,
-            "restingHrAutoUpdateUsed": False,
-            "sport": "DEFAULT",
-            "zone1Floor": 130,
-            "zone2Floor": 140,
-            "zone3Floor": 150,
-            "zone4Floor": 160,
-            "zone5Floor": 170,
-        }
-    ]
-    path = "/biometric-service/heartRateZones"
-    authed_client.put(
-        "connectapi",
-        path,
-        api=True,
-        json=data,
-    )
-    assert authed_client.connectapi(path)
-
-
-@pytest.mark.vcr
-def test_resume_login(client: Client):
-    result = client.login(
-        "example@example.com",
-        "correct_password",
-        return_on_mfa=True,
-    )
-
-    assert isinstance(result, tuple)
-    result_type, client_state = result
-
-    assert isinstance(client_state, dict)
-    assert result_type == "needs_mfa"
-    assert "login_params" in client_state
-    assert "client" in client_state
-
-    code = "123456"  # obtain from custom login
-
-    # test resuming the login
-    oauth1, oauth2 = client.resume_login(client_state, code)
-
-    assert oauth1
-    assert isinstance(oauth1, OAuth1Token)
-    assert oauth2
-    assert isinstance(oauth2, OAuth2Token)

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -1,113 +1,18 @@
 import time
 
 import pytest
-import requests
 
 from garth import sso
 from garth.auth_tokens import OAuth1Token, OAuth2Token
-from garth.exc import GarthException, GarthHTTPError
-from garth.http import Client
-
-
-@pytest.mark.vcr
-def test_login_email_password_fail(client: Client):
-    with pytest.raises(GarthException):
-        sso.login("user@example.com", "wrong_p@ssword", client=client)
-
-
-@pytest.mark.vcr
-def test_login_success(client: Client):
-    oauth1, oauth2 = sso.login(
-        "user@example.com", "correct_password", client=client
-    )
-
-    assert oauth1
-    assert isinstance(oauth1, OAuth1Token)
-    assert oauth2
-    assert isinstance(oauth2, OAuth2Token)
-
-
-@pytest.mark.vcr
-def test_login_success_mfa(monkeypatch, client: Client):
-    def mock_input(_):
-        return "671091"
-
-    monkeypatch.setattr("builtins.input", mock_input)
-    oauth1, oauth2 = sso.login(
-        "user@example.com", "correct_password", client=client
-    )
-
-    assert oauth1
-    assert isinstance(oauth1, OAuth1Token)
-    assert oauth2
-    assert isinstance(oauth2, OAuth2Token)
-
-
-@pytest.mark.vcr
-def test_login_success_mfa_async(monkeypatch, client: Client):
-    def mock_input(_):
-        return "031174"
-
-    async def prompt_mfa():
-        return input("MFA code: ")
-
-    monkeypatch.setattr("builtins.input", mock_input)
-    oauth1, oauth2 = sso.login(
-        "user@example.com",
-        "correct_password",
-        client=client,
-        prompt_mfa=prompt_mfa,
-    )
-
-    assert oauth1
-    assert isinstance(oauth1, OAuth1Token)
-    assert oauth2
-    assert isinstance(oauth2, OAuth2Token)
-
-
-@pytest.mark.vcr
-def test_login_mfa_fail(client: Client):
-    with pytest.raises(GarthException):
-        oauth1, oauth2 = sso.login(
-            "user@example.com",
-            "correct_password",
-            client=client,
-            prompt_mfa=lambda: "123456",
-        )
-
-
-@pytest.mark.vcr
-def test_login_return_on_mfa(client: Client):
-    result = sso.login(
-        "user@example.com",
-        "correct_password",
-        client=client,
-        return_on_mfa=True,
-    )
-
-    assert isinstance(result, tuple)
-    result_type, client_state = result
-
-    assert isinstance(client_state, dict)
-    assert result_type == "needs_mfa"
-    assert "login_params" in client_state
-    assert "client" in client_state
-
-    code = "123456"  # obtain from custom login
-
-    # test resuming the login
-    oauth1, oauth2 = sso.resume_login(client_state, code)
-
-    assert oauth1
-    assert isinstance(oauth1, OAuth1Token)
-    assert oauth2
-    assert isinstance(oauth2, OAuth2Token)
 
 
 def test_set_expirations(oauth2_token_dict: dict):
     token = sso.set_expirations(oauth2_token_dict)
     assert (
-        token["expires_at"] - time.time() - oauth2_token_dict["expires_in"] < 1
+        token["expires_at"]
+        - time.time()
+        - oauth2_token_dict["expires_in"]
+        < 1
     )
     assert (
         token["refresh_token_expires_at"]
@@ -117,97 +22,69 @@ def test_set_expirations(oauth2_token_dict: dict):
     )
 
 
-@pytest.mark.vcr
-def test_exchange(authed_client: Client):
-    assert authed_client.oauth1_token and isinstance(
-        authed_client.oauth1_token, OAuth1Token
+def test_exchange_returns_oauth2(oauth1_token: OAuth1Token):
+    from garth.http import Client
+
+    client = Client()
+    oauth2 = sso.exchange(oauth1_token, client)
+    assert isinstance(oauth2, OAuth2Token)
+    assert not oauth2.expired
+    assert oauth2.token_type == "Bearer"
+    assert oauth2.access_token == sso.BROWSER_TOKEN_SENTINEL
+
+
+def test_placeholder_oauth2():
+    token = sso._placeholder_oauth2()
+    assert isinstance(token, OAuth2Token)
+    assert token.access_token == sso.BROWSER_TOKEN_SENTINEL
+    assert not token.expired
+
+
+def test_is_browser_token():
+    oauth1 = OAuth1Token(
+        oauth_token=sso.BROWSER_TOKEN_SENTINEL,
+        oauth_token_secret=sso.BROWSER_TOKEN_SENTINEL,
+        domain="garmin.com",
     )
-    oauth1_token = authed_client.oauth1_token
-    oauth2_token = sso.exchange(oauth1_token, client=authed_client)
-    assert not oauth2_token.expired
-    assert not oauth2_token.refresh_expired
-    assert oauth2_token.token_type.title() == "Bearer"
-    assert authed_client.oauth2_token != oauth2_token
+    assert sso.is_browser_token(oauth1)
+
+    oauth1_real = OAuth1Token(
+        oauth_token="real_token",
+        oauth_token_secret="real_secret",
+        domain="garmin.com",
+    )
+    assert not sso.is_browser_token(oauth1_real)
+    assert not sso.is_browser_token(None)
 
 
-def test_parse_sso_response_success():
-    resp = {
-        "serviceTicketId": "ST-123",
-        "responseStatus": {
-            "type": "SUCCESSFUL",
-            "message": "",
-            "httpStatus": "OK",
-        },
-    }
-    result = sso._parse_sso_response(resp, "SUCCESSFUL")
-    assert result["serviceTicketId"] == "ST-123"
+def test_handle_mfa_not_implemented():
+    from garth.http import Client
+
+    client = Client()
+    with pytest.raises(NotImplementedError):
+        sso.handle_mfa(client, {}, lambda: "123456")
 
 
-def test_parse_sso_response_error():
-    resp = {
-        "responseStatus": {
-            "type": "INVALID_CREDENTIALS",
-            "message": "Bad password",
-            "httpStatus": "UNAUTHORIZED",
-        },
-    }
-    with pytest.raises(GarthException, match="INVALID_CREDENTIALS"):
-        sso._parse_sso_response(resp, "SUCCESSFUL")
+def test_resume_login_not_implemented():
+    with pytest.raises(NotImplementedError):
+        sso.resume_login({}, "123456")
 
 
-def test_parse_sso_response_no_expected():
-    resp = {
-        "responseStatus": {
-            "type": "MFA_REQUIRED",
-            "message": "",
-            "httpStatus": "OK",
-        },
-    }
-    result = sso._parse_sso_response(resp)
-    assert result["responseStatus"]["type"] == "MFA_REQUIRED"
+def test_get_page_returns_none_before_login():
+    assert sso.get_page() is None
 
 
-def test_handle_mfa_http_error(monkeypatch, client: Client):
-    from unittest.mock import MagicMock
-
-    def mock_post(*a, **kw):
-        raise GarthHTTPError(
-            msg="MFA verification failed",
-            error=requests.HTTPError(response=MagicMock()),
-        )
-
-    monkeypatch.setattr(client, "post", mock_post)
-
-    with pytest.raises(GarthHTTPError, match="MFA verification failed"):
-        sso.handle_mfa(client, {"clientId": "X"}, lambda: "123456")
+def test_get_csrf_returns_none_before_login():
+    assert sso.get_csrf() is None
 
 
-def test_login_unexpected_response_type(monkeypatch, client: Client):
-    from unittest.mock import MagicMock
+def test_close_is_safe_before_login():
+    sso.close()
 
-    unexpected_json = {
-        "responseStatus": {
-            "type": "CAPTCHA_REQUIRED",
-            "message": "solve captcha",
-            "httpStatus": "OK",
-        },
-    }
 
-    call_count = 0
-
-    def mock_request(method, *args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        mock_resp = MagicMock()
-        mock_resp.ok = True
-        mock_resp.status_code = 200
-        # First call is the cookie GET, second is the login POST
-        if call_count == 2:
-            mock_resp.json.return_value = unexpected_json
-        client.last_resp = mock_resp
-        return mock_resp
-
-    monkeypatch.setattr(client, "request", mock_request)
-
-    with pytest.raises(GarthException, match="CAPTCHA_REQUIRED"):
-        sso.login("user@example.com", "password", client=client)
+def test_close_clears_all_state():
+    sso.close()
+    assert sso.get_page() is None
+    assert sso.get_csrf() is None
+    assert sso._browser is None
+    assert sso._cm is None

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,27 +1,17 @@
-from unittest.mock import MagicMock
-
-import pytest
-from requests import Session
-
-from garth.http import Client
 from garth.telemetry import (
-    DEFAULT_TOKEN,
     REDACTED,
     Telemetry,
-    _scrubbing_callback,
     sanitize,
     sanitize_cookie,
     sanitize_headers,
 )
-from garth.version import __version__
 
 
 def test_sanitize_password():
-    text = '{"password": "secret123", "username": "user"}'
+    text = '{"username": "user@email.com", "password": "s3cr3t"}'
     result = sanitize(text)
-    assert "secret123" not in result
-    assert '"password": "[REDACTED]"' in result
-    assert "username" in result
+    assert "s3cr3t" not in result
+    assert REDACTED in result
 
 
 def test_sanitize_tokens():
@@ -29,119 +19,69 @@ def test_sanitize_tokens():
     result = sanitize(text)
     assert "abc123" not in result
     assert "xyz789" not in result
-    assert result.count("[REDACTED]") == 2
 
 
 def test_sanitize_oauth_tokens():
-    text = '{"oauth_token": "token1", "oauth_token_secret": "secret1"}'
+    text = '{"oauth_token": "abc", "oauth_token_secret": "xyz"}'
     result = sanitize(text)
-    assert "token1" not in result
-    assert "secret1" not in result
+    assert '"abc"' not in result
+    assert '"xyz"' not in result
 
 
 def test_sanitize_query_params():
-    text = "password=mysecret&username=user"
+    text = "password=s3cr3t&username=user@email.com&other=keep"
     result = sanitize(text)
-    assert "mysecret" not in result
-    assert "password=[REDACTED]" in result
+    assert "s3cr3t" not in result
+    assert "user@email.com" not in result
+    assert "keep" in result
 
 
-def test_telemetry_defaults(monkeypatch):
-    monkeypatch.delenv("GARTH_TELEMETRY_ENABLED", raising=False)
-    monkeypatch.delenv("GARTH_TELEMETRY_TOKEN", raising=False)
-    monkeypatch.delenv("GARTH_TELEMETRY_SEND_TO_LOGFIRE", raising=False)
-
+def test_telemetry_defaults():
     t = Telemetry()
-    assert t.enabled is False
-    assert t.send_to_logfire is False
-    assert t.token == DEFAULT_TOKEN
+    assert not t.enabled
+    assert not t.send_to_logfire
     assert t.callback is None
-    assert t.session_id  # non-empty
 
 
-def test_telemetry_configure_disabled(monkeypatch):
-    monkeypatch.delenv("GARTH_TELEMETRY_ENABLED", raising=False)
-    monkeypatch.delenv("GARTH_TELEMETRY_TOKEN", raising=False)
-    monkeypatch.delenv("GARTH_TELEMETRY_SEND_TO_LOGFIRE", raising=False)
-
+def test_telemetry_configure_disabled():
     t = Telemetry()
     t.configure(enabled=False)
-    assert t.enabled is False
-
-
-@pytest.mark.vcr
-def test_telemetry_enabled_request(authed_client: Client, monkeypatch):
-    """Test that telemetry works with real API requests (VCR recorded)."""
-    captured_data = []
-
-    def capture_callback(data):
-        captured_data.append(data)
-
-    authed_client.configure(
-        telemetry_enabled=True,
-        telemetry_callback=capture_callback,
-    )
-
-    assert authed_client.telemetry.enabled is True
-
-    profile = authed_client.connectapi("/userprofile-service/socialProfile")
-    assert profile is not None
-    assert "displayName" in profile
-
-    assert len(captured_data) == 1
-    assert captured_data[0]["method"] == "GET"
-    assert "userprofile-service" in captured_data[0]["url"]
-    assert captured_data[0]["status_code"] == 200
-    assert "session_id" in captured_data[0]
-    assert captured_data[0]["garth_version"] == __version__
+    assert not t.enabled
 
 
 def test_telemetry_env_override_disabled(monkeypatch):
     monkeypatch.setenv("GARTH_TELEMETRY_ENABLED", "false")
-
     t = Telemetry()
-    assert t.enabled is False
+    assert not t.enabled
 
 
-def test_telemetry_env_send_to_logfire_false(monkeypatch):
-    monkeypatch.setenv("GARTH_TELEMETRY_SEND_TO_LOGFIRE", "false")
-    monkeypatch.delenv("GARTH_TELEMETRY_ENABLED", raising=False)
-
-    t = Telemetry()
-    assert t.send_to_logfire is False
-
-
-def test_telemetry_configure_all_params(monkeypatch):
-    monkeypatch.delenv("GARTH_TELEMETRY_ENABLED", raising=False)
-    monkeypatch.delenv("GARTH_TELEMETRY_TOKEN", raising=False)
-    monkeypatch.delenv("GARTH_TELEMETRY_SEND_TO_LOGFIRE", raising=False)
-
-    t = Telemetry()
+def test_telemetry_configure_all_params():
     callback = lambda data: None  # noqa: E731
+    t = Telemetry()
     t.configure(
-        enabled=False,
+        enabled=True,
         send_to_logfire=False,
-        token="test-token",
+        token="test_token",
         callback=callback,
     )
-    assert t.enabled is False
-    assert t.send_to_logfire is False
-    assert t.token == "test-token"
-    assert t.callback is callback
+    assert t.enabled
+    assert not t.send_to_logfire
+    assert t.token == "test_token"
+    assert t.callback == callback
 
 
 def test_sanitize_cookie():
-    cookie = "session=abc123; path=/; domain=example.com"
+    cookie = "GARMIN-SSO=abc123; Path=/; Secure"
     result = sanitize_cookie(cookie)
     assert "abc123" not in result
-    assert f"session={REDACTED}" in result
+    assert REDACTED in result
 
 
 def test_sanitize_headers():
     headers = {
         "Authorization": "Bearer token123",
-        "Cookie": "session=abc",
         "Content-Type": "application/json",
+        "Cookie": "session=abc",
     }
     result = sanitize_headers(headers)
     assert result["Authorization"] == REDACTED
@@ -150,267 +90,12 @@ def test_sanitize_headers():
 
 
 def test_sanitize_headers_case_insensitive():
-    headers = {
-        "authorization": "Bearer token123",
-        "cookie": "session=abc",
-    }
+    headers = {"authorization": "Bearer token"}
     result = sanitize_headers(headers)
     assert result["authorization"] == REDACTED
-    assert result["cookie"] == REDACTED
-
-
-def test_response_hook_with_string_body():
-    captured_data = []
-    t = Telemetry()
-    t.enabled = True
-    t.callback = lambda data: captured_data.append(data)
-
-    response = MagicMock()
-    response.request = MagicMock()
-    response.request.method = "POST"
-    response.request.url = "https://example.com/api"
-    response.request.headers = {"Content-Type": "application/json"}
-    response.request.body = '{"password": "secret"}'
-    response.status_code = 200
-    response.headers = {"Content-Type": "application/json"}
-    response.text = '{"access_token": "token123"}'
-
-    t._response_hook(response)
-
-    assert len(captured_data) == 1
-    data = captured_data[0]
-    assert data["method"] == "POST"
-    assert data["url"] == "https://example.com/api"
-    assert data["status_code"] == 200
-    assert data["session_id"] == t.session_id
-    assert data["garth_version"] == __version__
-    assert "secret" not in data["request_body"]
-    assert "token123" not in data["response_body"]
-
-
-def test_response_hook_with_bytes_body():
-    captured_data = []
-    t = Telemetry()
-    t.enabled = True
-    t.callback = lambda data: captured_data.append(data)
-
-    response = MagicMock()
-    response.request = MagicMock()
-    response.request.method = "POST"
-    response.request.url = "https://example.com/api"
-    response.request.headers = {"Content-Type": "application/json"}
-    response.request.body = b'{"password": "secret"}'
-    response.status_code = 200
-    response.headers = {"Content-Type": "application/json"}
-    response.text = '{"data": "ok"}'
-
-    t._response_hook(response)
-
-    assert len(captured_data) == 1
-    assert "secret" not in captured_data[0]["request_body"]
-
-
-def test_response_hook_no_body():
-    captured_data = []
-    t = Telemetry()
-    t.enabled = True
-    t.callback = lambda data: captured_data.append(data)
-
-    response = MagicMock()
-    response.request = MagicMock()
-    response.request.method = "GET"
-    response.request.url = "https://example.com/api"
-    response.request.headers = {"Content-Type": "application/json"}
-    response.request.body = None
-    response.status_code = 200
-    response.headers = {"Content-Type": "application/json"}
-    response.text = '{"data": "ok"}'
-
-    t._response_hook(response)
-
-    assert len(captured_data) == 1
-    assert "request_body" not in captured_data[0]
-
-
-def test_response_hook_disabled():
-    captured_data = []
-    t = Telemetry()
-    t.enabled = False
-    t.callback = lambda data: captured_data.append(data)
-
-    response = MagicMock()
-    t._response_hook(response)
-
-    assert len(captured_data) == 0
-
-
-def test_response_hook_handles_exceptions():
-    t = Telemetry()
-    t.enabled = True
-    t.callback = lambda data: 1 / 0  # Will raise ZeroDivisionError
-
-    response = MagicMock()
-    response.request = MagicMock()
-    response.request.method = "GET"
-    response.request.url = "https://example.com/api"
-    response.request.headers = {}
-    response.request.body = None
-    response.status_code = 200
-    response.headers = {}
-    response.text = "{}"
-
-    # Should not raise
-    t._response_hook(response)
-
-
-def test_scrubbing_callback_bypasses_logfire_scrubbing():
-    m = MagicMock()
-    m.value = "test body"
-
-    result = _scrubbing_callback(m)
-    assert result == "test body"
-
-
-def test_telemetry_env_enabled_with_mock(monkeypatch):
-    import garth.telemetry as telemetry_module
-
-    monkeypatch.setenv("GARTH_TELEMETRY_ENABLED", "true")
-    monkeypatch.delenv("GARTH_TELEMETRY_TOKEN", raising=False)
-    monkeypatch.delenv("GARTH_TELEMETRY_SEND_TO_LOGFIRE", raising=False)
-
-    mock_logfire = MagicMock()
-    monkeypatch.setattr(telemetry_module, "logfire", mock_logfire)
-
-    t = Telemetry()
-    t.configure()
-
-    assert t.enabled is True
-    assert t._logfire_configured is True
-    mock_logfire.configure.assert_called_once()
-
-
-def test_telemetry_attach_to_session():
-    t = Telemetry()
-    t.enabled = True
-
-    session = Session()
-    initial_hook_count = len(session.hooks["response"])
-
-    t.attach(session)
-
-    assert len(session.hooks["response"]) == initial_hook_count + 1
-    assert t._response_hook in session.hooks["response"]
-
-
-def test_telemetry_attach_idempotent():
-    t = Telemetry()
-    t.enabled = True
-
-    session = Session()
-    initial_hook_count = len(session.hooks["response"])
-
-    t.attach(session)
-    t.attach(session)
-    t.attach(session)
-
-    assert len(session.hooks["response"]) == initial_hook_count + 1
-
-
-def test_telemetry_custom_callback_skips_logfire(monkeypatch):
-    monkeypatch.setenv("GARTH_TELEMETRY_ENABLED", "true")
-    monkeypatch.delenv("GARTH_TELEMETRY_TOKEN", raising=False)
-
-    t = Telemetry()
-    t.configure(callback=lambda data: None)
-
-    assert t.enabled is True
-    assert t._logfire_configured is False
-
-
-def test_client_telemetry_callback(monkeypatch):
-    monkeypatch.delenv("GARTH_HOME", raising=False)
-    monkeypatch.delenv("GARTH_TOKEN", raising=False)
-    monkeypatch.delenv("GARTH_TELEMETRY_ENABLED", raising=False)
-
-    captured_data = []
-    client = Client()
-    client.configure(
-        telemetry_enabled=True,
-        telemetry_callback=lambda data: captured_data.append(data),
-    )
-
-    assert client.telemetry.enabled is True
-    assert client.telemetry.callback is not None
-
-
-def test_default_callback_calls_logfire_instance():
-    mock_instance = MagicMock()
-
-    t = Telemetry()
-    t._logfire_configured = True
-    t._logfire_instance = mock_instance
-    data = {
-        "method": "GET",
-        "url": "https://example.com/api",
-        "status_code": 200,
-    }
-
-    t._default_callback(data)
-
-    mock_instance.info.assert_called_once_with(
-        "http {method} {url} {status_code}", **data
-    )
-
-
-def test_default_callback_skips_when_logfire_unavailable(monkeypatch):
-    import garth.telemetry as telemetry_module
-
-    monkeypatch.setattr(telemetry_module, "LOGFIRE_AVAILABLE", False)
-
-    t = Telemetry()
-    data = {
-        "method": "GET",
-        "url": "https://example.com/api",
-        "status_code": 200,
-    }
-
-    # Should not raise
-    t._default_callback(data)
-
-
-def test_configure_logfire_skips_when_unavailable(monkeypatch):
-    import garth.telemetry as telemetry_module
-
-    monkeypatch.setattr(telemetry_module, "LOGFIRE_AVAILABLE", False)
-
-    t = Telemetry()
-    t.enabled = True
-    t._configure_logfire()
-
-    assert t._logfire_configured is False
-
-
-def test_configure_logfire_uses_local_instance(monkeypatch):
-    """logfire.configure is called with local=True to avoid
-    overwriting the host app's logfire config."""
-    import garth.telemetry as telemetry_module
-
-    mock_logfire = MagicMock()
-    monkeypatch.setattr(telemetry_module, "logfire", mock_logfire)
-
-    t = Telemetry()
-    t.enabled = True
-    t._configure_logfire()
-
-    mock_logfire.configure.assert_called_once()
-    call_kwargs = mock_logfire.configure.call_args[1]
-    assert call_kwargs["local"] is True
-    assert call_kwargs["service_name"] == "garth"
-    assert t._logfire_instance is not None
 
 
 def test_session_id_unique():
     t1 = Telemetry()
     t2 = Telemetry()
     assert t1.session_id != t2.session_id
-    assert len(t1.session_id) == 16

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,15 @@ wheels = [
 ]
 
 [[package]]
+name = "apify-fingerprint-datapoints"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/a9/586b7ebdd682c047cd0b551dc7e154bb1480f8f6548154708e9a6c7844db/apify_fingerprint_datapoints-0.11.0.tar.gz", hash = "sha256:3f905c392b11a27fb59ccfe40891c166abd737ab9c6209733f102bbb3b302515", size = 969830, upload-time = "2026-03-01T01:00:04.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/38/9483eb52fc0f00039c684af627f8a8f994a8a99e8eceb869ba93b3fd740b/apify_fingerprint_datapoints-0.11.0-py3-none-any.whl", hash = "sha256:333340ccc3e520f19b5561e95d7abe2b31702e61d34b6247b328c9b8c93fbe1d", size = 726498, upload-time = "2026-03-01T01:00:03.103Z" },
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -39,6 +48,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "browserforge"
+version = "1.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "apify-fingerprint-datapoints" },
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/6f/8975af88d203efd70cc69477ebac702babef38201d04621c9583f2508f25/browserforge-1.2.4.tar.gz", hash = "sha256:05686473793769856ebd3528c69071f5be0e511260993e8b2ba839863711a0c4", size = 36700, upload-time = "2026-02-03T02:52:09.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/35/ce962f738ae28ffce6293e7607b129075633e6bb185a5ab87e49246eedc2/browserforge-1.2.4-py3-none-any.whl", hash = "sha256:fb1c14e62ac09de221dcfc73074200269f697596c642cb200ceaab1127a17542", size = 37890, upload-time = "2026-02-03T02:52:08.745Z" },
+]
+
+[[package]]
+name = "camoufox"
+version = "0.4.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "browserforge" },
+    { name = "click" },
+    { name = "language-tags" },
+    { name = "lxml" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "orjson" },
+    { name = "platformdirs" },
+    { name = "playwright" },
+    { name = "pysocks" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "screeninfo" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "ua-parser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/15/e0a1b586e354ea6b8d6612717bf4372aaaa6753444d5d006caf0bb116466/camoufox-0.4.11.tar.gz", hash = "sha256:0a2c9d24ac5070c104e7c2b125c0a3937f70efa416084ef88afe94c32a72eebe", size = 64409, upload-time = "2025-01-29T09:33:20.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/7b/a2f099a5afb9660271b3f20f6056ba679e7ab4eba42682266a65d5730f7e/camoufox-0.4.11-py3-none-any.whl", hash = "sha256:83864d434d159a7566990aa6524429a8d1a859cbf84d2f64ef4a9f29e7d2e5ff", size = 71628, upload-time = "2025-01-29T09:33:18.558Z" },
 ]
 
 [[package]]
@@ -553,6 +602,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cython"
+version = "3.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/85/7574c9cd44b69a27210444b6650f6477f56c75fee1b70d7672d3e4166167/cython-3.2.4.tar.gz", hash = "sha256:84226ecd313b233da27dc2eb3601b4f222b8209c3a7216d8733b031da1dc64e6", size = 3280291, upload-time = "2026-01-04T14:14:14.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/10/720e0fb84eab4c927c4dd6b61eb7993f7732dd83d29ba6d73083874eade9/cython-3.2.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02cb0cc0f23b9874ad262d7d2b9560aed9c7e2df07b49b920bda6f2cc9cb505e", size = 2960836, upload-time = "2026-01-04T14:14:51.103Z" },
+    { url = "https://files.pythonhosted.org/packages/85/cc/8f06145ec3efa121c8b1b67f06a640386ddacd77ee3e574da582a21b14ee/cython-3.2.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ff9af2134c05e3734064808db95b4dd7341a39af06e8945d05ea358e1741aaed", size = 2953769, upload-time = "2026-01-04T14:15:00.361Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4d/1eb0c7c196a136b1926f4d7f0492a96c6fabd604d77e6cd43b56a3a16d83/cython-3.2.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:64d7f71be3dd6d6d4a4c575bb3a4674ea06d1e1e5e4cd1b9882a2bc40ed3c4c9", size = 2970064, upload-time = "2026-01-04T14:15:08.567Z" },
+    { url = "https://files.pythonhosted.org/packages/18/b5/1cfca43b7d20a0fdb1eac67313d6bb6b18d18897f82dd0f17436bdd2ba7f/cython-3.2.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:28e8075087a59756f2d059273184b8b639fe0f16cf17470bd91c39921bc154e0", size = 2960506, upload-time = "2026-01-04T14:15:16.733Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/d7/3bda3efce0c5c6ce79cc21285dbe6f60369c20364e112f5a506ee8a1b067/cython-3.2.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d4b4fd5332ab093131fa6172e8362f16adef3eac3179fd24bbdc392531cb82fa", size = 2971496, upload-time = "2026-01-04T14:15:25.038Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/8b/fd393f0923c82be4ec0db712fffb2ff0a7a131707b842c99bf24b549274d/cython-3.2.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:36bf3f5eb56d5281aafabecbaa6ed288bc11db87547bba4e1e52943ae6961ccf", size = 2875622, upload-time = "2026-01-04T14:15:39.749Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/fa/d3c15189f7c52aaefbaea76fb012119b04b9013f4bf446cb4eb4c26c4e6b/cython-3.2.4-py3-none-any.whl", hash = "sha256:732fc93bc33ae4b14f6afaca663b916c2fdd5dcbfad7114e17fb2434eeaea45c", size = 1257078, upload-time = "2026-01-04T14:14:12.373Z" },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.20"
 source = { registry = "https://pypi.org/simple" }
@@ -693,11 +757,10 @@ wheels = [
 name = "garth"
 source = { editable = "." }
 dependencies = [
-    { name = "logfire" },
+    { name = "camoufox" },
+    { name = "playwright" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "requests" },
-    { name = "requests-oauthlib" },
 ]
 
 [package.optional-dependencies]
@@ -725,16 +788,15 @@ testing = [
     { name = "freezegun" },
     { name = "logfire" },
     { name = "pytest" },
-    { name = "pytest-vcr" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "logfire", specifier = ">=2.11,<5.0" },
+    { name = "camoufox", specifier = ">=0.4" },
+    { name = "playwright", specifier = ">=1.40" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0,<3.0.0" },
-    { name = "requests", specifier = ">=2.0.0,<3.0.0" },
-    { name = "requests-oauthlib", specifier = ">=1.3.1,<3.0.0" },
     { name = "zensical", marker = "extra == 'docs'" },
 ]
 provides-extras = ["docs"]
@@ -756,7 +818,7 @@ testing = [
     { name = "freezegun" },
     { name = "logfire", specifier = ">=2.11,<5.0" },
     { name = "pytest" },
-    { name = "pytest-vcr" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]
@@ -769,6 +831,66 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/99/96/a0205167fa0154f4a542fd6925bdc63d039d88dab3588b875078107e6f06/googleapis_common_protos-1.73.0.tar.gz", hash = "sha256:778d07cd4fbeff84c6f7c72102f0daf98fa2bfd3fa8bea426edc545588da0b5a", size = 147323, upload-time = "2026-03-06T21:53:09.727Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/28/23eea8acd65972bbfe295ce3666b28ac510dfcb115fac089d3edb0feb00a/googleapis_common_protos-1.73.0-py3-none-any.whl", hash = "sha256:dfdaaa2e860f242046be561e6d6cb5c5f1541ae02cfbcb034371aadb2942b4e8", size = 297578, upload-time = "2026-03-06T21:52:33.933Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/51/1664f6b78fc6ebbd98019a1fd730e83fa78f2db7058f72b1463d3612b8db/greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2", size = 188267, upload-time = "2026-02-20T20:54:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3f/9859f655d11901e7b2996c6e3d33e0caa9a1d4572c3bc61ed0faa64b2f4c/greenlet-3.3.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9bc885b89709d901859cf95179ec9f6bb67a3d2bb1f0e88456461bd4b7f8fd0d", size = 277747, upload-time = "2026-02-20T20:16:21.325Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/07/cb284a8b5c6498dbd7cba35d31380bb123d7dceaa7907f606c8ff5993cbf/greenlet-3.3.2-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b568183cf65b94919be4438dc28416b234b678c608cafac8874dfeeb2a9bbe13", size = 579202, upload-time = "2026-02-20T20:47:28.955Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/45/67922992b3a152f726163b19f890a85129a992f39607a2a53155de3448b8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:527fec58dc9f90efd594b9b700662ed3fb2493c2122067ac9c740d98080a620e", size = 590620, upload-time = "2026-02-20T20:55:55.581Z" },
+    { url = "https://files.pythonhosted.org/packages/03/5f/6e2a7d80c353587751ef3d44bb947f0565ec008a2e0927821c007e96d3a7/greenlet-3.3.2-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508c7f01f1791fbc8e011bd508f6794cb95397fdb198a46cb6635eb5b78d85a7", size = 602132, upload-time = "2026-02-20T21:02:43.261Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/55/9f1ebb5a825215fadcc0f7d5073f6e79e3007e3282b14b22d6aba7ca6cb8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad0c8917dd42a819fe77e6bdfcb84e3379c0de956469301d9fd36427a1ca501f", size = 591729, upload-time = "2026-02-20T20:20:58.395Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/21f5455773d37f94b866eb3cf5caed88d6cea6dd2c6e1f9c34f463cba3ec/greenlet-3.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:97245cc10e5515dbc8c3104b2928f7f02b6813002770cfaffaf9a6e0fc2b94ef", size = 1551946, upload-time = "2026-02-20T20:49:31.102Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/91f061a926abead128fe1a87f0b453ccf07368666bd59ffa46016627a930/greenlet-3.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8c1fdd7d1b309ff0da81d60a9688a8bd044ac4e18b250320a96fc68d31c209ca", size = 1618494, upload-time = "2026-02-20T20:21:06.541Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/78/f93e840cbaef8becaf6adafbaf1319682a6c2d8c1c20224267a5c6c8c891/greenlet-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:5d0e35379f93a6d0222de929a25ab47b5eb35b5ef4721c2b9cbcc4036129ff1f", size = 230092, upload-time = "2026-02-20T20:17:09.379Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
+    { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
+    { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3a/efb2cf697fbccdf75b24e2c18025e7dfa54c4f31fab75c51d0fe79942cef/greenlet-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e692b2dae4cc7077cbb11b47d258533b48c8fde69a33d0d8a82e2fe8d8531d5", size = 230389, upload-time = "2026-02-20T20:17:18.772Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a1/65bbc059a43a7e2143ec4fc1f9e3f673e04f9c7b371a494a101422ac4fd5/greenlet-3.3.2-cp311-cp311-win_arm64.whl", hash = "sha256:02b0a8682aecd4d3c6c18edf52bc8e51eacdd75c8eac52a790a210b06aa295fd", size = 229645, upload-time = "2026-02-20T20:18:18.695Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
+    { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/cc802e067d02af8b60b6771cea7d57e21ef5e6659912814babb42b864713/greenlet-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:34308836d8370bddadb41f5a7ce96879b72e2fdfb4e87729330c6ab52376409f", size = 231081, upload-time = "2026-02-20T20:17:28.121Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2e/fe7f36ff1982d6b10a60d5e0740c759259a7d6d2e1dc41da6d96de32fff6/greenlet-3.3.2-cp312-cp312-win_arm64.whl", hash = "sha256:d3a62fa76a32b462a97198e4c9e99afb9ab375115e74e9a83ce180e7a496f643", size = 230331, upload-time = "2026-02-20T20:17:23.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
+    { url = "https://files.pythonhosted.org/packages/91/39/5ef5aa23bc545aa0d31e1b9b55822b32c8da93ba657295840b6b34124009/greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124", size = 230961, upload-time = "2026-02-20T20:16:58.461Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6b/a89f8456dcb06becff288f563618e9f20deed8dd29beea14f9a168aef64b/greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327", size = 230221, upload-time = "2026-02-20T20:17:37.152Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ca/2101ca3d9223a1dc125140dbc063644dca76df6ff356531eb27bc267b446/greenlet-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492", size = 232034, upload-time = "2026-02-20T20:20:08.186Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/4a/ecf894e962a59dea60f04877eea0fd5724618da89f1867b28ee8b91e811f/greenlet-3.3.2-cp314-cp314-win_arm64.whl", hash = "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71", size = 231437, upload-time = "2026-02-20T20:18:59.722Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
 ]
 
 [[package]]
@@ -1102,6 +1224,15 @@ wheels = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/7e/b6a0efe4fee11e9742c1baaedf7c574084238a70b03c1d8eb2761383848f/language_tags-1.2.0.tar.gz", hash = "sha256:e934acba3e3dc85f867703eca421847a9ab7b7679b11b5d5cfd096febbf8bde6", size = 207901, upload-time = "2023-01-11T18:38:07.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/42/327554649ed2dd5ce59d3f5da176c7be20f9352c7c6c51597293660b7b08/language_tags-1.2.0-py3-none-any.whl", hash = "sha256:d815604622242fdfbbfd747b40c31213617fd03734a267f2e39ee4bd73c88722", size = 213449, upload-time = "2023-01-11T18:38:05.692Z" },
+]
+
+[[package]]
 name = "logfire"
 version = "4.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1118,6 +1249,130 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/40/3d09fe09cfa63753feada2d41dd909ce0741dd5731014a4b3eb31bdee977/logfire-4.29.0.tar.gz", hash = "sha256:18a306a0b5744aee8ad0a8f5d6b3a47a6d8951c340eaecc42dc5d0224f4bdca0", size = 1057563, upload-time = "2026-03-13T15:30:24.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/aa/fb8102ea48924fbbb9dfced7bada5717875801808ad53f9a60b6b4fec440/logfire-4.29.0-py3-none-any.whl", hash = "sha256:8dd7fdf6bed21459b8893eaa290d61977b9ebcc901844e365ddee868b5d8bca8", size = 302227, upload-time = "2026-03-13T15:30:20.742Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", size = 4073426, upload-time = "2025-09-22T04:04:59.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/8a/f8192a08237ef2fb1b19733f709db88a4c43bc8ab8357f01cb41a27e7f6a/lxml-6.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e77dd455b9a16bbd2a5036a63ddbd479c19572af81b624e79ef422f929eef388", size = 8590589, upload-time = "2025-09-22T04:00:10.51Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/27bcd07ae17ff5e5536e8d88f4c7d581b48963817a13de11f3ac3329bfa2/lxml-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5d444858b9f07cefff6455b983aea9a67f7462ba1f6cbe4a21e8bf6791bf2153", size = 4629671, upload-time = "2025-09-22T04:00:15.411Z" },
+    { url = "https://files.pythonhosted.org/packages/02/5a/a7d53b3291c324e0b6e48f3c797be63836cc52156ddf8f33cd72aac78866/lxml-6.0.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f952dacaa552f3bb8834908dddd500ba7d508e6ea6eb8c52eb2d28f48ca06a31", size = 4999961, upload-time = "2025-09-22T04:00:17.619Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/55/d465e9b89df1761674d8672bb3e4ae2c47033b01ec243964b6e334c6743f/lxml-6.0.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71695772df6acea9f3c0e59e44ba8ac50c4f125217e84aab21074a1a55e7e5c9", size = 5157087, upload-time = "2025-09-22T04:00:19.868Z" },
+    { url = "https://files.pythonhosted.org/packages/62/38/3073cd7e3e8dfc3ba3c3a139e33bee3a82de2bfb0925714351ad3d255c13/lxml-6.0.2-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17f68764f35fd78d7c4cc4ef209a184c38b65440378013d24b8aecd327c3e0c8", size = 5067620, upload-time = "2025-09-22T04:00:21.877Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d3/1e001588c5e2205637b08985597827d3827dbaaece16348c8822bfe61c29/lxml-6.0.2-cp310-cp310-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:058027e261afed589eddcfe530fcc6f3402d7fd7e89bfd0532df82ebc1563dba", size = 5406664, upload-time = "2025-09-22T04:00:23.714Z" },
+    { url = "https://files.pythonhosted.org/packages/20/cf/cab09478699b003857ed6ebfe95e9fb9fa3d3c25f1353b905c9b73cfb624/lxml-6.0.2-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8ffaeec5dfea5881d4c9d8913a32d10cfe3923495386106e4a24d45300ef79c", size = 5289397, upload-time = "2025-09-22T04:00:25.544Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/84/02a2d0c38ac9a8b9f9e5e1bbd3f24b3f426044ad618b552e9549ee91bd63/lxml-6.0.2-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:f2e3b1a6bb38de0bc713edd4d612969dd250ca8b724be8d460001a387507021c", size = 4772178, upload-time = "2025-09-22T04:00:27.602Z" },
+    { url = "https://files.pythonhosted.org/packages/56/87/e1ceadcc031ec4aa605fe95476892d0b0ba3b7f8c7dcdf88fdeff59a9c86/lxml-6.0.2-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d6690ec5ec1cce0385cb20896b16be35247ac8c2046e493d03232f1c2414d321", size = 5358148, upload-time = "2025-09-22T04:00:29.323Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/13/5bb6cf42bb228353fd4ac5f162c6a84fd68a4d6f67c1031c8cf97e131fc6/lxml-6.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f2a50c3c1d11cad0ebebbac357a97b26aa79d2bcaf46f256551152aa85d3a4d1", size = 5112035, upload-time = "2025-09-22T04:00:31.061Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e2/ea0498552102e59834e297c5c6dff8d8ded3db72ed5e8aad77871476f073/lxml-6.0.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:3efe1b21c7801ffa29a1112fab3b0f643628c30472d507f39544fd48e9549e34", size = 4799111, upload-time = "2025-09-22T04:00:33.11Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9e/8de42b52a73abb8af86c66c969b3b4c2a96567b6ac74637c037d2e3baa60/lxml-6.0.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:59c45e125140b2c4b33920d21d83681940ca29f0b83f8629ea1a2196dc8cfe6a", size = 5351662, upload-time = "2025-09-22T04:00:35.237Z" },
+    { url = "https://files.pythonhosted.org/packages/28/a2/de776a573dfb15114509a37351937c367530865edb10a90189d0b4b9b70a/lxml-6.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:452b899faa64f1805943ec1c0c9ebeaece01a1af83e130b69cdefeda180bb42c", size = 5314973, upload-time = "2025-09-22T04:00:37.086Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a0/3ae1b1f8964c271b5eec91db2043cf8c6c0bce101ebb2a633b51b044db6c/lxml-6.0.2-cp310-cp310-win32.whl", hash = "sha256:1e786a464c191ca43b133906c6903a7e4d56bef376b75d97ccbb8ec5cf1f0a4b", size = 3611953, upload-time = "2025-09-22T04:00:39.224Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/70/bd42491f0634aad41bdfc1e46f5cff98825fb6185688dc82baa35d509f1a/lxml-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:dacf3c64ef3f7440e3167aa4b49aa9e0fb99e0aa4f9ff03795640bf94531bcb0", size = 4032695, upload-time = "2025-09-22T04:00:41.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d0/05c6a72299f54c2c561a6c6cbb2f512e047fca20ea97a05e57931f194ac4/lxml-6.0.2-cp310-cp310-win_arm64.whl", hash = "sha256:45f93e6f75123f88d7f0cfd90f2d05f441b808562bf0bc01070a00f53f5028b5", size = 3680051, upload-time = "2025-09-22T04:00:43.525Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d5/becbe1e2569b474a23f0c672ead8a29ac50b2dc1d5b9de184831bda8d14c/lxml-6.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:13e35cbc684aadf05d8711a5d1b5857c92e5e580efa9a0d2be197199c8def607", size = 8634365, upload-time = "2025-09-22T04:00:45.672Z" },
+    { url = "https://files.pythonhosted.org/packages/28/66/1ced58f12e804644426b85d0bb8a4478ca77bc1761455da310505f1a3526/lxml-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b1675e096e17c6fe9c0e8c81434f5736c0739ff9ac6123c87c2d452f48fc938", size = 4650793, upload-time = "2025-09-22T04:00:47.783Z" },
+    { url = "https://files.pythonhosted.org/packages/11/84/549098ffea39dfd167e3f174b4ce983d0eed61f9d8d25b7bf2a57c3247fc/lxml-6.0.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac6e5811ae2870953390452e3476694196f98d447573234592d30488147404d", size = 4944362, upload-time = "2025-09-22T04:00:49.845Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/bd/f207f16abf9749d2037453d56b643a7471d8fde855a231a12d1e095c4f01/lxml-6.0.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5aa0fc67ae19d7a64c3fe725dc9a1bb11f80e01f78289d05c6f62545affec438", size = 5083152, upload-time = "2025-09-22T04:00:51.709Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ae/bd813e87d8941d52ad5b65071b1affb48da01c4ed3c9c99e40abb266fbff/lxml-6.0.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de496365750cc472b4e7902a485d3f152ecf57bd3ba03ddd5578ed8ceb4c5964", size = 5023539, upload-time = "2025-09-22T04:00:53.593Z" },
+    { url = "https://files.pythonhosted.org/packages/02/cd/9bfef16bd1d874fbe0cb51afb00329540f30a3283beb9f0780adbb7eec03/lxml-6.0.2-cp311-cp311-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:200069a593c5e40b8f6fc0d84d86d970ba43138c3e68619ffa234bc9bb806a4d", size = 5344853, upload-time = "2025-09-22T04:00:55.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/89/ea8f91594bc5dbb879734d35a6f2b0ad50605d7fb419de2b63d4211765cc/lxml-6.0.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d2de809c2ee3b888b59f995625385f74629707c9355e0ff856445cdcae682b7", size = 5225133, upload-time = "2025-09-22T04:00:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/37/9c735274f5dbec726b2db99b98a43950395ba3d4a1043083dba2ad814170/lxml-6.0.2-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:b2c3da8d93cf5db60e8858c17684c47d01fee6405e554fb55018dd85fc23b178", size = 4677944, upload-time = "2025-09-22T04:00:59.052Z" },
+    { url = "https://files.pythonhosted.org/packages/20/28/7dfe1ba3475d8bfca3878365075abe002e05d40dfaaeb7ec01b4c587d533/lxml-6.0.2-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:442de7530296ef5e188373a1ea5789a46ce90c4847e597856570439621d9c553", size = 5284535, upload-time = "2025-09-22T04:01:01.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/cf/5f14bc0de763498fc29510e3532bf2b4b3a1c1d5d0dff2e900c16ba021ef/lxml-6.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2593c77efde7bfea7f6389f1ab249b15ed4aa5bc5cb5131faa3b843c429fbedb", size = 5067343, upload-time = "2025-09-22T04:01:03.13Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b0/bb8275ab5472f32b28cfbbcc6db7c9d092482d3439ca279d8d6fa02f7025/lxml-6.0.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3e3cb08855967a20f553ff32d147e14329b3ae70ced6edc2f282b94afbc74b2a", size = 4725419, upload-time = "2025-09-22T04:01:05.013Z" },
+    { url = "https://files.pythonhosted.org/packages/25/4c/7c222753bc72edca3b99dbadba1b064209bc8ed4ad448af990e60dcce462/lxml-6.0.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2ed6c667fcbb8c19c6791bbf40b7268ef8ddf5a96940ba9404b9f9a304832f6c", size = 5275008, upload-time = "2025-09-22T04:01:07.327Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/8c/478a0dc6b6ed661451379447cdbec77c05741a75736d97e5b2b729687828/lxml-6.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b8f18914faec94132e5b91e69d76a5c1d7b0c73e2489ea8929c4aaa10b76bbf7", size = 5248906, upload-time = "2025-09-22T04:01:09.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d9/5be3a6ab2784cdf9accb0703b65e1b64fcdd9311c9f007630c7db0cfcce1/lxml-6.0.2-cp311-cp311-win32.whl", hash = "sha256:6605c604e6daa9e0d7f0a2137bdc47a2e93b59c60a65466353e37f8272f47c46", size = 3610357, upload-time = "2025-09-22T04:01:11.102Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/7d/ca6fb13349b473d5732fb0ee3eec8f6c80fc0688e76b7d79c1008481bf1f/lxml-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e5867f2651016a3afd8dd2c8238baa66f1e2802f44bc17e236f547ace6647078", size = 4036583, upload-time = "2025-09-22T04:01:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a2/51363b5ecd3eab46563645f3a2c3836a2fc67d01a1b87c5017040f39f567/lxml-6.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:4197fb2534ee05fd3e7afaab5d8bfd6c2e186f65ea7f9cd6a82809c887bd1285", size = 3680591, upload-time = "2025-09-22T04:01:14.874Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c8/8ff2bc6b920c84355146cd1ab7d181bc543b89241cfb1ebee824a7c81457/lxml-6.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a59f5448ba2ceccd06995c95ea59a7674a10de0810f2ce90c9006f3cbc044456", size = 8661887, upload-time = "2025-09-22T04:01:17.265Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/9aae1008083bb501ef63284220ce81638332f9ccbfa53765b2b7502203cf/lxml-6.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e8113639f3296706fbac34a30813929e29247718e88173ad849f57ca59754924", size = 4667818, upload-time = "2025-09-22T04:01:19.688Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ca/31fb37f99f37f1536c133476674c10b577e409c0a624384147653e38baf2/lxml-6.0.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a8bef9b9825fa8bc816a6e641bb67219489229ebc648be422af695f6e7a4fa7f", size = 4950807, upload-time = "2025-09-22T04:01:21.487Z" },
+    { url = "https://files.pythonhosted.org/packages/da/87/f6cb9442e4bada8aab5ae7e1046264f62fdbeaa6e3f6211b93f4c0dd97f1/lxml-6.0.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:65ea18d710fd14e0186c2f973dc60bb52039a275f82d3c44a0e42b43440ea534", size = 5109179, upload-time = "2025-09-22T04:01:23.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/20/a7760713e65888db79bbae4f6146a6ae5c04e4a204a3c48896c408cd6ed2/lxml-6.0.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c371aa98126a0d4c739ca93ceffa0fd7a5d732e3ac66a46e74339acd4d334564", size = 5023044, upload-time = "2025-09-22T04:01:25.118Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b0/7e64e0460fcb36471899f75831509098f3fd7cd02a3833ac517433cb4f8f/lxml-6.0.2-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:700efd30c0fa1a3581d80a748157397559396090a51d306ea59a70020223d16f", size = 5359685, upload-time = "2025-09-22T04:01:27.398Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e1/e5df362e9ca4e2f48ed6411bd4b3a0ae737cc842e96877f5bf9428055ab4/lxml-6.0.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c33e66d44fe60e72397b487ee92e01da0d09ba2d66df8eae42d77b6d06e5eba0", size = 5654127, upload-time = "2025-09-22T04:01:29.629Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d1/232b3309a02d60f11e71857778bfcd4acbdb86c07db8260caf7d008b08f8/lxml-6.0.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90a345bbeaf9d0587a3aaffb7006aa39ccb6ff0e96a57286c0cb2fd1520ea192", size = 5253958, upload-time = "2025-09-22T04:01:31.535Z" },
+    { url = "https://files.pythonhosted.org/packages/35/35/d955a070994725c4f7d80583a96cab9c107c57a125b20bb5f708fe941011/lxml-6.0.2-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:064fdadaf7a21af3ed1dcaa106b854077fbeada827c18f72aec9346847cd65d0", size = 4711541, upload-time = "2025-09-22T04:01:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/be/667d17363b38a78c4bd63cfd4b4632029fd68d2c2dc81f25ce9eb5224dd5/lxml-6.0.2-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fbc74f42c3525ac4ffa4b89cbdd00057b6196bcefe8bce794abd42d33a018092", size = 5267426, upload-time = "2025-09-22T04:01:35.639Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/62c70aa4a1c26569bc958c9ca86af2bb4e1f614e8c04fb2989833874f7ae/lxml-6.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6ddff43f702905a4e32bc24f3f2e2edfe0f8fde3277d481bffb709a4cced7a1f", size = 5064917, upload-time = "2025-09-22T04:01:37.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/55/6ceddaca353ebd0f1908ef712c597f8570cc9c58130dbb89903198e441fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6da5185951d72e6f5352166e3da7b0dc27aa70bd1090b0eb3f7f7212b53f1bb8", size = 4788795, upload-time = "2025-09-22T04:01:39.165Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e8/fd63e15da5e3fd4c2146f8bbb3c14e94ab850589beab88e547b2dbce22e1/lxml-6.0.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:57a86e1ebb4020a38d295c04fc79603c7899e0df71588043eb218722dabc087f", size = 5676759, upload-time = "2025-09-22T04:01:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/76/47/b3ec58dc5c374697f5ba37412cd2728f427d056315d124dd4b61da381877/lxml-6.0.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2047d8234fe735ab77802ce5f2297e410ff40f5238aec569ad7c8e163d7b19a6", size = 5255666, upload-time = "2025-09-22T04:01:43.363Z" },
+    { url = "https://files.pythonhosted.org/packages/19/93/03ba725df4c3d72afd9596eef4a37a837ce8e4806010569bedfcd2cb68fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f91fd2b2ea15a6800c8e24418c0775a1694eefc011392da73bc6cef2623b322", size = 5277989, upload-time = "2025-09-22T04:01:45.215Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/80/c06de80bfce881d0ad738576f243911fccf992687ae09fd80b734712b39c/lxml-6.0.2-cp312-cp312-win32.whl", hash = "sha256:3ae2ce7d6fedfb3414a2b6c5e20b249c4c607f72cb8d2bb7cc9c6ec7c6f4e849", size = 3611456, upload-time = "2025-09-22T04:01:48.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/d7/0cdfb6c3e30893463fb3d1e52bc5f5f99684a03c29a0b6b605cfae879cd5/lxml-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:72c87e5ee4e58a8354fb9c7c84cbf95a1c8236c127a5d1b7683f04bed8361e1f", size = 4011793, upload-time = "2025-09-22T04:01:50.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/93c73c67db235931527301ed3785f849c78991e2e34f3fd9a6663ffda4c5/lxml-6.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:61cb10eeb95570153e0c0e554f58df92ecf5109f75eacad4a95baa709e26c3d6", size = 3672836, upload-time = "2025-09-22T04:01:52.145Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/4e8f0540608977aea078bf6d79f128e0e2c2bba8af1acf775c30baa70460/lxml-6.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9b33d21594afab46f37ae58dfadd06636f154923c4e8a4d754b0127554eb2e77", size = 8648494, upload-time = "2025-09-22T04:01:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f4/2a94a3d3dfd6c6b433501b8d470a1960a20ecce93245cf2db1706adf6c19/lxml-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c8963287d7a4c5c9a432ff487c52e9c5618667179c18a204bdedb27310f022f", size = 4661146, upload-time = "2025-09-22T04:01:56.282Z" },
+    { url = "https://files.pythonhosted.org/packages/25/2e/4efa677fa6b322013035d38016f6ae859d06cac67437ca7dc708a6af7028/lxml-6.0.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1941354d92699fb5ffe6ed7b32f9649e43c2feb4b97205f75866f7d21aa91452", size = 4946932, upload-time = "2025-09-22T04:01:58.989Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/0f/526e78a6d38d109fdbaa5049c62e1d32fdd70c75fb61c4eadf3045d3d124/lxml-6.0.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb2f6ca0ae2d983ded09357b84af659c954722bbf04dea98030064996d156048", size = 5100060, upload-time = "2025-09-22T04:02:00.812Z" },
+    { url = "https://files.pythonhosted.org/packages/81/76/99de58d81fa702cc0ea7edae4f4640416c2062813a00ff24bd70ac1d9c9b/lxml-6.0.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb2a12d704f180a902d7fa778c6d71f36ceb7b0d317f34cdc76a5d05aa1dd1df", size = 5019000, upload-time = "2025-09-22T04:02:02.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/9e57d25482bc9a9882cb0037fdb9cc18f4b79d85df94fa9d2a89562f1d25/lxml-6.0.2-cp313-cp313-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:6ec0e3f745021bfed19c456647f0298d60a24c9ff86d9d051f52b509663feeb1", size = 5348496, upload-time = "2025-09-22T04:02:04.904Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8e/cb99bd0b83ccc3e8f0f528e9aa1f7a9965dfec08c617070c5db8d63a87ce/lxml-6.0.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:846ae9a12d54e368933b9759052d6206a9e8b250291109c48e350c1f1f49d916", size = 5643779, upload-time = "2025-09-22T04:02:06.689Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/34/9e591954939276bb679b73773836c6684c22e56d05980e31d52a9a8deb18/lxml-6.0.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef9266d2aa545d7374938fb5c484531ef5a2ec7f2d573e62f8ce722c735685fd", size = 5244072, upload-time = "2025-09-22T04:02:08.587Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/27/b29ff065f9aaca443ee377aff699714fcbffb371b4fce5ac4ca759e436d5/lxml-6.0.2-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:4077b7c79f31755df33b795dc12119cb557a0106bfdab0d2c2d97bd3cf3dffa6", size = 4718675, upload-time = "2025-09-22T04:02:10.783Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f756f9c2cd27caa1a6ef8c32ae47aadea697f5c2c6d07b0dae133c244fbe/lxml-6.0.2-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a7c5d5e5f1081955358533be077166ee97ed2571d6a66bdba6ec2f609a715d1a", size = 5255171, upload-time = "2025-09-22T04:02:12.631Z" },
+    { url = "https://files.pythonhosted.org/packages/61/46/bb85ea42d2cb1bd8395484fd72f38e3389611aa496ac7772da9205bbda0e/lxml-6.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f8d0cbd0674ee89863a523e6994ac25fd5be9c8486acfc3e5ccea679bad2679", size = 5057175, upload-time = "2025-09-22T04:02:14.718Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0c/443fc476dcc8e41577f0af70458c50fe299a97bb6b7505bb1ae09aa7f9ac/lxml-6.0.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:2cbcbf6d6e924c28f04a43f3b6f6e272312a090f269eff68a2982e13e5d57659", size = 4785688, upload-time = "2025-09-22T04:02:16.957Z" },
+    { url = "https://files.pythonhosted.org/packages/48/78/6ef0b359d45bb9697bc5a626e1992fa5d27aa3f8004b137b2314793b50a0/lxml-6.0.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dfb874cfa53340009af6bdd7e54ebc0d21012a60a4e65d927c2e477112e63484", size = 5660655, upload-time = "2025-09-22T04:02:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ea/e1d33808f386bc1339d08c0dcada6e4712d4ed8e93fcad5f057070b7988a/lxml-6.0.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb8dae0b6b8b7f9e96c26fdd8121522ce5de9bb5538010870bd538683d30e9a2", size = 5247695, upload-time = "2025-09-22T04:02:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/47/eba75dfd8183673725255247a603b4ad606f4ae657b60c6c145b381697da/lxml-6.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:358d9adae670b63e95bc59747c72f4dc97c9ec58881d4627fe0120da0f90d314", size = 5269841, upload-time = "2025-09-22T04:02:22.489Z" },
+    { url = "https://files.pythonhosted.org/packages/76/04/5c5e2b8577bc936e219becb2e98cdb1aca14a4921a12995b9d0c523502ae/lxml-6.0.2-cp313-cp313-win32.whl", hash = "sha256:e8cd2415f372e7e5a789d743d133ae474290a90b9023197fd78f32e2dc6873e2", size = 3610700, upload-time = "2025-09-22T04:02:24.465Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0a/4643ccc6bb8b143e9f9640aa54e38255f9d3b45feb2cbe7ae2ca47e8782e/lxml-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:b30d46379644fbfc3ab81f8f82ae4de55179414651f110a1514f0b1f8f6cb2d7", size = 4010347, upload-time = "2025-09-22T04:02:26.286Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ef/dcf1d29c3f530577f61e5fe2f1bd72929acf779953668a8a47a479ae6f26/lxml-6.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:13dcecc9946dca97b11b7c40d29fba63b55ab4170d3c0cf8c0c164343b9bfdcf", size = 3671248, upload-time = "2025-09-22T04:02:27.918Z" },
+    { url = "https://files.pythonhosted.org/packages/03/15/d4a377b385ab693ce97b472fe0c77c2b16ec79590e688b3ccc71fba19884/lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:b0c732aa23de8f8aec23f4b580d1e52905ef468afb4abeafd3fec77042abb6fe", size = 8659801, upload-time = "2025-09-22T04:02:30.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e8/c128e37589463668794d503afaeb003987373c5f94d667124ffd8078bbd9/lxml-6.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4468e3b83e10e0317a89a33d28f7aeba1caa4d1a6fd457d115dd4ffe90c5931d", size = 4659403, upload-time = "2025-09-22T04:02:32.119Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ce/74903904339decdf7da7847bb5741fc98a5451b42fc419a86c0c13d26fe2/lxml-6.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:abd44571493973bad4598a3be7e1d807ed45aa2adaf7ab92ab7c62609569b17d", size = 4966974, upload-time = "2025-09-22T04:02:34.155Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d3/131dec79ce61c5567fecf82515bd9bc36395df42501b50f7f7f3bd065df0/lxml-6.0.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:370cd78d5855cfbffd57c422851f7d3864e6ae72d0da615fca4dad8c45d375a5", size = 5102953, upload-time = "2025-09-22T04:02:36.054Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ea/a43ba9bb750d4ffdd885f2cd333572f5bb900cd2408b67fdda07e85978a0/lxml-6.0.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:901e3b4219fa04ef766885fb40fa516a71662a4c61b80c94d25336b4934b71c0", size = 5055054, upload-time = "2025-09-22T04:02:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/23/6885b451636ae286c34628f70a7ed1fcc759f8d9ad382d132e1c8d3d9bfd/lxml-6.0.2-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:a4bf42d2e4cf52c28cc1812d62426b9503cdb0c87a6de81442626aa7d69707ba", size = 5352421, upload-time = "2025-09-22T04:02:40.413Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5b/fc2ddfc94ddbe3eebb8e9af6e3fd65e2feba4967f6a4e9683875c394c2d8/lxml-6.0.2-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2c7fdaa4d7c3d886a42534adec7cfac73860b89b4e5298752f60aa5984641a0", size = 5673684, upload-time = "2025-09-22T04:02:42.288Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/47293c58cc91769130fbf85531280e8cc7868f7fbb6d92f4670071b9cb3e/lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98a5e1660dc7de2200b00d53fa00bcd3c35a3608c305d45a7bbcaf29fa16e83d", size = 5252463, upload-time = "2025-09-22T04:02:44.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/da/ba6eceb830c762b48e711ded880d7e3e89fc6c7323e587c36540b6b23c6b/lxml-6.0.2-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:dc051506c30b609238d79eda75ee9cab3e520570ec8219844a72a46020901e37", size = 4698437, upload-time = "2025-09-22T04:02:46.524Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/24/7be3f82cb7990b89118d944b619e53c656c97dc89c28cfb143fdb7cd6f4d/lxml-6.0.2-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8799481bbdd212470d17513a54d568f44416db01250f49449647b5ab5b5dccb9", size = 5269890, upload-time = "2025-09-22T04:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/dcfb9ea1e16c665efd7538fc5d5c34071276ce9220e234217682e7d2c4a5/lxml-6.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9261bb77c2dab42f3ecd9103951aeca2c40277701eb7e912c545c1b16e0e4917", size = 5097185, upload-time = "2025-09-22T04:02:50.746Z" },
+    { url = "https://files.pythonhosted.org/packages/21/04/a60b0ff9314736316f28316b694bccbbabe100f8483ad83852d77fc7468e/lxml-6.0.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:65ac4a01aba353cfa6d5725b95d7aed6356ddc0a3cd734de00124d285b04b64f", size = 4745895, upload-time = "2025-09-22T04:02:52.968Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/bd/7d54bd1846e5a310d9c715921c5faa71cf5c0853372adf78aee70c8d7aa2/lxml-6.0.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:b22a07cbb82fea98f8a2fd814f3d1811ff9ed76d0fc6abc84eb21527596e7cc8", size = 5695246, upload-time = "2025-09-22T04:02:54.798Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/5643d6ab947bc371da21323acb2a6e603cedbe71cb4c99c8254289ab6f4e/lxml-6.0.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d759cdd7f3e055d6bc8d9bec3ad905227b2e4c785dc16c372eb5b5e83123f48a", size = 5260797, upload-time = "2025-09-22T04:02:57.058Z" },
+    { url = "https://files.pythonhosted.org/packages/33/da/34c1ec4cff1eea7d0b4cd44af8411806ed943141804ac9c5d565302afb78/lxml-6.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:945da35a48d193d27c188037a05fec5492937f66fb1958c24fc761fb9d40d43c", size = 5277404, upload-time = "2025-09-22T04:02:58.966Z" },
+    { url = "https://files.pythonhosted.org/packages/82/57/4eca3e31e54dc89e2c3507e1cd411074a17565fa5ffc437c4ae0a00d439e/lxml-6.0.2-cp314-cp314-win32.whl", hash = "sha256:be3aaa60da67e6153eb15715cc2e19091af5dc75faef8b8a585aea372507384b", size = 3670072, upload-time = "2025-09-22T04:03:38.05Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/e0/c96cf13eccd20c9421ba910304dae0f619724dcf1702864fd59dd386404d/lxml-6.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:fa25afbadead523f7001caf0c2382afd272c315a033a7b06336da2637d92d6ed", size = 4080617, upload-time = "2025-09-22T04:03:39.835Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5d/b3f03e22b3d38d6f188ef044900a9b29b2fe0aebb94625ce9fe244011d34/lxml-6.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8", size = 3754930, upload-time = "2025-09-22T04:03:41.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/5c/42c2c4c03554580708fc738d13414801f340c04c3eff90d8d2d227145275/lxml-6.0.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6162a86d86893d63084faaf4ff937b3daea233e3682fb4474db07395794fa80d", size = 8910380, upload-time = "2025-09-22T04:03:01.645Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4f/12df843e3e10d18d468a7557058f8d3733e8b6e12401f30b1ef29360740f/lxml-6.0.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:414aaa94e974e23a3e92e7ca5b97d10c0cf37b6481f50911032c69eeb3991bba", size = 4775632, upload-time = "2025-09-22T04:03:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0c/9dc31e6c2d0d418483cbcb469d1f5a582a1cd00a1f4081953d44051f3c50/lxml-6.0.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48461bd21625458dd01e14e2c38dd0aea69addc3c4f960c30d9f59d7f93be601", size = 4975171, upload-time = "2025-09-22T04:03:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2b/9b870c6ca24c841bdd887504808f0417aa9d8d564114689266f19ddf29c8/lxml-6.0.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25fcc59afc57d527cfc78a58f40ab4c9b8fd096a9a3f964d2781ffb6eb33f4ed", size = 5110109, upload-time = "2025-09-22T04:03:07.452Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0c/4f5f2a4dd319a178912751564471355d9019e220c20d7db3fb8307ed8582/lxml-6.0.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5179c60288204e6ddde3f774a93350177e08876eaf3ab78aa3a3649d43eb7d37", size = 5041061, upload-time = "2025-09-22T04:03:09.297Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/554eed290365267671fe001a20d72d14f468ae4e6acef1e179b039436967/lxml-6.0.2-cp314-cp314t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:967aab75434de148ec80597b75062d8123cadf2943fb4281f385141e18b21338", size = 5306233, upload-time = "2025-09-22T04:03:11.651Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/31/1d748aa275e71802ad9722df32a7a35034246b42c0ecdd8235412c3396ef/lxml-6.0.2-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d100fcc8930d697c6561156c6810ab4a508fb264c8b6779e6e61e2ed5e7558f9", size = 5604739, upload-time = "2025-09-22T04:03:13.592Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/41/2c11916bcac09ed561adccacceaedd2bf0e0b25b297ea92aab99fd03d0fa/lxml-6.0.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ca59e7e13e5981175b8b3e4ab84d7da57993eeff53c07764dcebda0d0e64ecd", size = 5225119, upload-time = "2025-09-22T04:03:15.408Z" },
+    { url = "https://files.pythonhosted.org/packages/99/05/4e5c2873d8f17aa018e6afde417c80cc5d0c33be4854cce3ef5670c49367/lxml-6.0.2-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:957448ac63a42e2e49531b9d6c0fa449a1970dbc32467aaad46f11545be9af1d", size = 4633665, upload-time = "2025-09-22T04:03:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c9/dcc2da1bebd6275cdc723b515f93edf548b82f36a5458cca3578bc899332/lxml-6.0.2-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b7fc49c37f1786284b12af63152fe1d0990722497e2d5817acfe7a877522f9a9", size = 5234997, upload-time = "2025-09-22T04:03:19.14Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e2/5172e4e7468afca64a37b81dba152fc5d90e30f9c83c7c3213d6a02a5ce4/lxml-6.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e19e0643cc936a22e837f79d01a550678da8377d7d801a14487c10c34ee49c7e", size = 5090957, upload-time = "2025-09-22T04:03:21.436Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b3/15461fd3e5cd4ddcb7938b87fc20b14ab113b92312fc97afe65cd7c85de1/lxml-6.0.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1db01e5cf14345628e0cbe71067204db658e2fb8e51e7f33631f5f4735fefd8d", size = 4764372, upload-time = "2025-09-22T04:03:23.27Z" },
+    { url = "https://files.pythonhosted.org/packages/05/33/f310b987c8bf9e61c4dd8e8035c416bd3230098f5e3cfa69fc4232de7059/lxml-6.0.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:875c6b5ab39ad5291588aed6925fac99d0097af0dd62f33c7b43736043d4a2ec", size = 5634653, upload-time = "2025-09-22T04:03:25.767Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/51c80e75e0bc9382158133bdcf4e339b5886c6ee2418b5199b3f1a61ed6d/lxml-6.0.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cdcbed9ad19da81c480dfd6dd161886db6096083c9938ead313d94b30aadf272", size = 5233795, upload-time = "2025-09-22T04:03:27.62Z" },
+    { url = "https://files.pythonhosted.org/packages/56/4d/4856e897df0d588789dd844dbed9d91782c4ef0b327f96ce53c807e13128/lxml-6.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:80dadc234ebc532e09be1975ff538d154a7fa61ea5031c03d25178855544728f", size = 5257023, upload-time = "2025-09-22T04:03:30.056Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/85/86766dfebfa87bea0ab78e9ff7a4b4b45225df4b4d3b8cc3c03c5cd68464/lxml-6.0.2-cp314-cp314t-win32.whl", hash = "sha256:da08e7bb297b04e893d91087df19638dc7a6bb858a954b0cc2b9f5053c922312", size = 3911420, upload-time = "2025-09-22T04:03:32.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1a/b248b355834c8e32614650b8008c69ffeb0ceb149c793961dd8c0b991bb3/lxml-6.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:252a22982dca42f6155125ac76d3432e548a7625d56f5a273ee78a5057216eca", size = 4406837, upload-time = "2025-09-22T04:03:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/92/aa/df863bcc39c5e0946263454aba394de8a9084dbaff8ad143846b0d844739/lxml-6.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:bb4c1847b303835d89d785a18801a883436cdfd5dc3d62947f9c49e24f0f5a2c", size = 3822205, upload-time = "2025-09-22T04:03:36.249Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/9c/780c9a8fce3f04690b374f72f41306866b0400b9d0fdf3e17aaa37887eed/lxml-6.0.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:e748d4cf8fef2526bb2a589a417eba0c8674e29ffcb570ce2ceca44f1e567bf6", size = 3939264, upload-time = "2025-09-22T04:04:32.892Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5a/1ab260c00adf645d8bf7dec7f920f744b032f69130c681302821d5debea6/lxml-6.0.2-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4ddb1049fa0579d0cbd00503ad8c58b9ab34d1254c77bc6a5576d96ec7853dba", size = 4216435, upload-time = "2025-09-22T04:04:34.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/37/565f3b3d7ffede22874b6d86be1a1763d00f4ea9fc5b9b6ccb11e4ec8612/lxml-6.0.2-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cb233f9c95f83707dae461b12b720c1af9c28c2d19208e1be03387222151daf5", size = 4325913, upload-time = "2025-09-22T04:04:37.205Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ec/f3a1b169b2fb9d03467e2e3c0c752ea30e993be440a068b125fc7dd248b0/lxml-6.0.2-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc456d04db0515ce3320d714a1eac7a97774ff0849e7718b492d957da4631dd4", size = 4269357, upload-time = "2025-09-22T04:04:39.322Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a2/585a28fe3e67daa1cf2f06f34490d556d121c25d500b10082a7db96e3bcd/lxml-6.0.2-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2613e67de13d619fd283d58bda40bff0ee07739f624ffee8b13b631abf33083d", size = 4412295, upload-time = "2025-09-22T04:04:41.647Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/a57dd8bcebd7c69386c20263830d4fa72d27e6b72a229ef7a48e88952d9a/lxml-6.0.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:24a8e756c982c001ca8d59e87c80c4d9dcd4d9b44a4cbeb8d9be4482c514d41d", size = 3516913, upload-time = "2025-09-22T04:04:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/11/29d08bc103a62c0eba8016e7ed5aeebbf1e4312e83b0b1648dd203b0e87d/lxml-6.0.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1c06035eafa8404b5cf475bb37a9f6088b0aca288d4ccc9d69389750d5543700", size = 3949829, upload-time = "2025-09-22T04:04:45.608Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b3/52ab9a3b31e5ab8238da241baa19eec44d2ab426532441ee607165aebb52/lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c7d13103045de1bdd6fe5d61802565f1a3537d70cd3abf596aa0af62761921ee", size = 4226277, upload-time = "2025-09-22T04:04:47.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/33/1eaf780c1baad88224611df13b1c2a9dfa460b526cacfe769103ff50d845/lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a3c150a95fbe5ac91de323aa756219ef9cf7fde5a3f00e2281e30f33fa5fa4f", size = 4330433, upload-time = "2025-09-22T04:04:49.907Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c1/27428a2ff348e994ab4f8777d3a0ad510b6b92d37718e5887d2da99952a2/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60fa43be34f78bebb27812ed90f1925ec99560b0fa1decdb7d12b84d857d31e9", size = 4272119, upload-time = "2025-09-22T04:04:51.801Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d0/3020fa12bcec4ab62f97aab026d57c2f0cfd480a558758d9ca233bb6a79d/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21c73b476d3cfe836be731225ec3421fa2f048d84f6df6a8e70433dff1376d5a", size = 4417314, upload-time = "2025-09-22T04:04:55.024Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/77/d7f491cbc05303ac6801651aabeb262d43f319288c1ea96c66b1d2692ff3/lxml-6.0.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:27220da5be049e936c3aca06f174e8827ca6445a4353a1995584311487fc4e3e", size = 3518768, upload-time = "2025-09-22T04:04:57.097Z" },
 ]
 
 [[package]]
@@ -1402,15 +1657,6 @@ wheels = [
 ]
 
 [[package]]
-name = "oauthlib"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
-]
-
-[[package]]
 name = "opentelemetry-api"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1505,6 +1751,87 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/45/b268004f745ede84e5798b48ee12b05129d19235d0e15267aa57dcdb400b/orjson-3.11.7.tar.gz", hash = "sha256:9b1a67243945819ce55d24a30b59d6a168e86220452d2c96f4d1f093e71c0c49", size = 6144992, upload-time = "2026-02-02T15:38:49.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1a/a373746fa6d0e116dd9e54371a7b54622c44d12296d5d0f3ad5e3ff33490/orjson-3.11.7-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:a02c833f38f36546ba65a452127633afce4cf0dd7296b753d3bb54e55e5c0174", size = 229140, upload-time = "2026-02-02T15:37:06.082Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a2/fa129e749d500f9b183e8a3446a193818a25f60261e9ce143ad61e975208/orjson-3.11.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b63c6e6738d7c3470ad01601e23376aa511e50e1f3931395b9f9c722406d1a67", size = 128670, upload-time = "2026-02-02T15:37:08.002Z" },
+    { url = "https://files.pythonhosted.org/packages/08/93/1e82011cd1e0bd051ef9d35bed1aa7fb4ea1f0a055dc2c841b46b43a9ebd/orjson-3.11.7-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:043d3006b7d32c7e233b8cfb1f01c651013ea079e08dcef7189a29abd8befe11", size = 123832, upload-time = "2026-02-02T15:37:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d8/a26b431ef962c7d55736674dddade876822f3e33223c1f47a36879350d04/orjson-3.11.7-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57036b27ac8a25d81112eb0cc9835cd4833c5b16e1467816adc0015f59e870dc", size = 129171, upload-time = "2026-02-02T15:37:11.112Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/19/f47819b84a580f490da260c3ee9ade214cf4cf78ac9ce8c1c758f80fdfc9/orjson-3.11.7-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:733ae23ada68b804b222c44affed76b39e30806d38660bf1eb200520d259cc16", size = 141967, upload-time = "2026-02-02T15:37:12.282Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/cd/37ece39a0777ba077fdcdbe4cccae3be8ed00290c14bf8afdc548befc260/orjson-3.11.7-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5fdfad2093bdd08245f2e204d977facd5f871c88c4a71230d5bcbd0e43bf6222", size = 130991, upload-time = "2026-02-02T15:37:13.465Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ed/f2b5d66aa9b6b5c02ff5f120efc7b38c7c4962b21e6be0f00fd99a5c348e/orjson-3.11.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cededd6738e1c153530793998e31c05086582b08315db48ab66649768f326baa", size = 133674, upload-time = "2026-02-02T15:37:14.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6e/baa83e68d1aa09fa8c3e5b2c087d01d0a0bd45256de719ed7bc22c07052d/orjson-3.11.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:14f440c7268c8f8633d1b3d443a434bd70cb15686117ea6beff8fdc8f5917a1e", size = 138722, upload-time = "2026-02-02T15:37:16.501Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/47/7f8ef4963b772cd56999b535e553f7eb5cd27e9dd6c049baee6f18bfa05d/orjson-3.11.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:3a2479753bbb95b0ebcf7969f562cdb9668e6d12416a35b0dda79febf89cdea2", size = 409056, upload-time = "2026-02-02T15:37:17.895Z" },
+    { url = "https://files.pythonhosted.org/packages/38/eb/2df104dd2244b3618f25325a656f85cc3277f74bbd91224752410a78f3c7/orjson-3.11.7-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:71924496986275a737f38e3f22b4e0878882b3f7a310d2ff4dc96e812789120c", size = 144196, upload-time = "2026-02-02T15:37:19.349Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2a/ee41de0aa3a6686598661eae2b4ebdff1340c65bfb17fcff8b87138aab21/orjson-3.11.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b4a9eefdc70bf8bf9857f0290f973dec534ac84c35cd6a7f4083be43e7170a8f", size = 134979, upload-time = "2026-02-02T15:37:20.906Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fa/92fc5d3d402b87a8b28277a9ed35386218a6a5287c7fe5ee9b9f02c53fb2/orjson-3.11.7-cp310-cp310-win32.whl", hash = "sha256:ae9e0b37a834cef7ce8f99de6498f8fad4a2c0bf6bfc3d02abd8ed56aa15b2de", size = 127968, upload-time = "2026-02-02T15:37:23.178Z" },
+    { url = "https://files.pythonhosted.org/packages/07/29/a576bf36d73d60df06904d3844a9df08e25d59eba64363aaf8ec2f9bff41/orjson-3.11.7-cp310-cp310-win_amd64.whl", hash = "sha256:d772afdb22555f0c58cfc741bdae44180122b3616faa1ecadb595cd526e4c993", size = 125128, upload-time = "2026-02-02T15:37:24.329Z" },
+    { url = "https://files.pythonhosted.org/packages/37/02/da6cb01fc6087048d7f61522c327edf4250f1683a58a839fdcc435746dd5/orjson-3.11.7-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9487abc2c2086e7c8eb9a211d2ce8855bae0e92586279d0d27b341d5ad76c85c", size = 228664, upload-time = "2026-02-02T15:37:25.542Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/c2/5885e7a5881dba9a9af51bc564e8967225a642b3e03d089289a35054e749/orjson-3.11.7-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:79cacb0b52f6004caf92405a7e1f11e6e2de8bdf9019e4f76b44ba045125cd6b", size = 125344, upload-time = "2026-02-02T15:37:26.92Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1d/4e7688de0a92d1caf600dfd5fb70b4c5bfff51dfa61ac555072ef2d0d32a/orjson-3.11.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2e85fe4698b6a56d5e2ebf7ae87544d668eb6bde1ad1226c13f44663f20ec9e", size = 128404, upload-time = "2026-02-02T15:37:28.108Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/b2/ec04b74ae03a125db7bd69cffd014b227b7f341e3261bf75b5eb88a1aa92/orjson-3.11.7-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b8d14b71c0b12963fe8a62aac87119f1afdf4cb88a400f61ca5ae581449efcb5", size = 123677, upload-time = "2026-02-02T15:37:30.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/69/f95bdf960605f08f827f6e3291fe243d8aa9c5c9ff017a8d7232209184c3/orjson-3.11.7-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91c81ef070c8f3220054115e1ef468b1c9ce8497b4e526cb9f68ab4dc0a7ac62", size = 128950, upload-time = "2026-02-02T15:37:31.595Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1b/de59c57bae1d148ef298852abd31909ac3089cff370dfd4cd84cc99cbc42/orjson-3.11.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:411ebaf34d735e25e358a6d9e7978954a9c9d58cfb47bc6683cdc3964cd2f910", size = 141756, upload-time = "2026-02-02T15:37:32.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/9e/9decc59f4499f695f65c650f6cfa6cd4c37a3fbe8fa235a0a3614cb54386/orjson-3.11.7-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a16bcd08ab0bcdfc7e8801d9c4a9cc17e58418e4d48ddc6ded4e9e4b1a94062b", size = 130812, upload-time = "2026-02-02T15:37:34.204Z" },
+    { url = "https://files.pythonhosted.org/packages/28/e6/59f932bcabd1eac44e334fe8e3281a92eacfcb450586e1f4bde0423728d8/orjson-3.11.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c0b51672e466fd7e56230ffbae7f1639e18d0ce023351fb75da21b71bc2c960", size = 133444, upload-time = "2026-02-02T15:37:35.446Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/36/b0f05c0eaa7ca30bc965e37e6a2956b0d67adb87a9872942d3568da846ae/orjson-3.11.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:136dcd6a2e796dfd9ffca9fc027d778567b0b7c9968d092842d3c323cef88aa8", size = 138609, upload-time = "2026-02-02T15:37:36.657Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/03/58ec7d302b8d86944c60c7b4b82975d5161fcce4c9bc8c6cb1d6741b6115/orjson-3.11.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:7ba61079379b0ae29e117db13bda5f28d939766e410d321ec1624afc6a0b0504", size = 408918, upload-time = "2026-02-02T15:37:38.076Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3a/868d65ef9a8b99be723bd510de491349618abd9f62c826cf206d962db295/orjson-3.11.7-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0527a4510c300e3b406591b0ba69b5dc50031895b0a93743526a3fc45f59d26e", size = 143998, upload-time = "2026-02-02T15:37:39.706Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c7/1e18e1c83afe3349f4f6dc9e14910f0ae5f82eac756d1412ea4018938535/orjson-3.11.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a709e881723c9b18acddcfb8ba357322491ad553e277cf467e1e7e20e2d90561", size = 134802, upload-time = "2026-02-02T15:37:41.002Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0b/ccb7ee1a65b37e8eeb8b267dc953561d72370e85185e459616d4345bab34/orjson-3.11.7-cp311-cp311-win32.whl", hash = "sha256:c43b8b5bab288b6b90dac410cca7e986a4fa747a2e8f94615aea407da706980d", size = 127828, upload-time = "2026-02-02T15:37:42.241Z" },
+    { url = "https://files.pythonhosted.org/packages/af/9e/55c776dffda3f381e0f07d010a4f5f3902bf48eaba1bb7684d301acd4924/orjson-3.11.7-cp311-cp311-win_amd64.whl", hash = "sha256:6543001328aa857187f905308a028935864aefe9968af3848401b6fe80dbb471", size = 124941, upload-time = "2026-02-02T15:37:43.444Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/8e/424a620fa7d263b880162505fb107ef5e0afaa765b5b06a88312ac291560/orjson-3.11.7-cp311-cp311-win_arm64.whl", hash = "sha256:1ee5cc7160a821dfe14f130bc8e63e7611051f964b463d9e2a3a573204446a4d", size = 126245, upload-time = "2026-02-02T15:37:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/80/bf/76f4f1665f6983385938f0e2a5d7efa12a58171b8456c252f3bae8a4cf75/orjson-3.11.7-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:bd03ea7606833655048dab1a00734a2875e3e86c276e1d772b2a02556f0d895f", size = 228545, upload-time = "2026-02-02T15:37:46.376Z" },
+    { url = "https://files.pythonhosted.org/packages/79/53/6c72c002cb13b5a978a068add59b25a8bdf2800ac1c9c8ecdb26d6d97064/orjson-3.11.7-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:89e440ebc74ce8ab5c7bc4ce6757b4a6b1041becb127df818f6997b5c71aa60b", size = 125224, upload-time = "2026-02-02T15:37:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/83/10e48852865e5dd151bdfe652c06f7da484578ed02c5fca938e3632cb0b8/orjson-3.11.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ede977b5fe5ac91b1dffc0a517ca4542d2ec8a6a4ff7b2652d94f640796342a", size = 128154, upload-time = "2026-02-02T15:37:48.954Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/52/a66e22a2b9abaa374b4a081d410edab6d1e30024707b87eab7c734afe28d/orjson-3.11.7-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b7b1dae39230a393df353827c855a5f176271c23434cfd2db74e0e424e693e10", size = 123548, upload-time = "2026-02-02T15:37:50.187Z" },
+    { url = "https://files.pythonhosted.org/packages/de/38/605d371417021359f4910c496f764c48ceb8997605f8c25bf1dfe58c0ebe/orjson-3.11.7-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed46f17096e28fb28d2975834836a639af7278aa87c84f68ab08fbe5b8bd75fa", size = 129000, upload-time = "2026-02-02T15:37:51.426Z" },
+    { url = "https://files.pythonhosted.org/packages/44/98/af32e842b0ffd2335c89714d48ca4e3917b42f5d6ee5537832e069a4b3ac/orjson-3.11.7-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3726be79e36e526e3d9c1aceaadbfb4a04ee80a72ab47b3f3c17fefb9812e7b8", size = 141686, upload-time = "2026-02-02T15:37:52.607Z" },
+    { url = "https://files.pythonhosted.org/packages/96/0b/fc793858dfa54be6feee940c1463370ece34b3c39c1ca0aa3845f5ba9892/orjson-3.11.7-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0724e265bc548af1dedebd9cb3d24b4e1c1e685a343be43e87ba922a5c5fff2f", size = 130812, upload-time = "2026-02-02T15:37:53.944Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/91/98a52415059db3f374757d0b7f0f16e3b5cd5976c90d1c2b56acaea039e6/orjson-3.11.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7745312efa9e11c17fbd3cb3097262d079da26930ae9ae7ba28fb738367cbad", size = 133440, upload-time = "2026-02-02T15:37:55.615Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b6/cb540117bda61791f46381f8c26c8f93e802892830a6055748d3bb1925ab/orjson-3.11.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f904c24bdeabd4298f7a977ef14ca2a022ca921ed670b92ecd16ab6f3d01f867", size = 138386, upload-time = "2026-02-02T15:37:56.814Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1a/50a3201c334a7f17c231eee5f841342190723794e3b06293f26e7cf87d31/orjson-3.11.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b9fc4d0f81f394689e0814617aadc4f2ea0e8025f38c226cbf22d3b5ddbf025d", size = 408853, upload-time = "2026-02-02T15:37:58.291Z" },
+    { url = "https://files.pythonhosted.org/packages/87/cd/8de1c67d0be44fdc22701e5989c0d015a2adf391498ad42c4dc589cd3013/orjson-3.11.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:849e38203e5be40b776ed2718e587faf204d184fc9a008ae441f9442320c0cab", size = 144130, upload-time = "2026-02-02T15:38:00.163Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/fe/d605d700c35dd55f51710d159fc54516a280923cd1b7e47508982fbb387d/orjson-3.11.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4682d1db3bcebd2b64757e0ddf9e87ae5f00d29d16c5cdf3a62f561d08cc3dd2", size = 134818, upload-time = "2026-02-02T15:38:01.507Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e4/15ecc67edb3ddb3e2f46ae04475f2d294e8b60c1825fbe28a428b93b3fbd/orjson-3.11.7-cp312-cp312-win32.whl", hash = "sha256:f4f7c956b5215d949a1f65334cf9d7612dde38f20a95f2315deef167def91a6f", size = 127923, upload-time = "2026-02-02T15:38:02.75Z" },
+    { url = "https://files.pythonhosted.org/packages/34/70/2e0855361f76198a3965273048c8e50a9695d88cd75811a5b46444895845/orjson-3.11.7-cp312-cp312-win_amd64.whl", hash = "sha256:bf742e149121dc5648ba0a08ea0871e87b660467ef168a3a5e53bc1fbd64bb74", size = 125007, upload-time = "2026-02-02T15:38:04.032Z" },
+    { url = "https://files.pythonhosted.org/packages/68/40/c2051bd19fc467610fed469dc29e43ac65891571138f476834ca192bc290/orjson-3.11.7-cp312-cp312-win_arm64.whl", hash = "sha256:26c3b9132f783b7d7903bf1efb095fed8d4a3a85ec0d334ee8beff3d7a4749d5", size = 126089, upload-time = "2026-02-02T15:38:05.297Z" },
+    { url = "https://files.pythonhosted.org/packages/89/25/6e0e52cac5aab51d7b6dcd257e855e1dec1c2060f6b28566c509b4665f62/orjson-3.11.7-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:1d98b30cc1313d52d4af17d9c3d307b08389752ec5f2e5febdfada70b0f8c733", size = 228390, upload-time = "2026-02-02T15:38:06.8Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/29/a77f48d2fc8a05bbc529e5ff481fb43d914f9e383ea2469d4f3d51df3d00/orjson-3.11.7-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:d897e81f8d0cbd2abb82226d1860ad2e1ab3ff16d7b08c96ca00df9d45409ef4", size = 125189, upload-time = "2026-02-02T15:38:08.181Z" },
+    { url = "https://files.pythonhosted.org/packages/89/25/0a16e0729a0e6a1504f9d1a13cdd365f030068aab64cec6958396b9969d7/orjson-3.11.7-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:814be4b49b228cfc0b3c565acf642dd7d13538f966e3ccde61f4f55be3e20785", size = 128106, upload-time = "2026-02-02T15:38:09.41Z" },
+    { url = "https://files.pythonhosted.org/packages/66/da/a2e505469d60666a05ab373f1a6322eb671cb2ba3a0ccfc7d4bc97196787/orjson-3.11.7-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d06e5c5fed5caedd2e540d62e5b1c25e8c82431b9e577c33537e5fa4aa909539", size = 123363, upload-time = "2026-02-02T15:38:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bf/ed73f88396ea35c71b38961734ea4a4746f7ca0768bf28fd551d37e48dd0/orjson-3.11.7-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:31c80ce534ac4ea3739c5ee751270646cbc46e45aea7576a38ffec040b4029a1", size = 129007, upload-time = "2026-02-02T15:38:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/73/3c/b05d80716f0225fc9008fbf8ab22841dcc268a626aa550561743714ce3bf/orjson-3.11.7-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f50979824bde13d32b4320eedd513431c921102796d86be3eee0b58e58a3ecd1", size = 141667, upload-time = "2026-02-02T15:38:13.398Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e8/0be9b0addd9bf86abfc938e97441dcd0375d494594b1c8ad10fe57479617/orjson-3.11.7-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e54f3808e2b6b945078c41aa8d9b5834b28c50843846e97807e5adb75fa9705", size = 130832, upload-time = "2026-02-02T15:38:14.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ec/c68e3b9021a31d9ec15a94931db1410136af862955854ed5dd7e7e4f5bff/orjson-3.11.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a12b80df61aab7b98b490fe9e4879925ba666fccdfcd175252ce4d9035865ace", size = 133373, upload-time = "2026-02-02T15:38:16.109Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/45/f3466739aaafa570cc8e77c6dbb853c48bf56e3b43738020e2661e08b0ac/orjson-3.11.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:996b65230271f1a97026fd0e6a753f51fbc0c335d2ad0c6201f711b0da32693b", size = 138307, upload-time = "2026-02-02T15:38:17.453Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/84/9f7f02288da1ffb31405c1be07657afd1eecbcb4b64ee2817b6fe0f785fa/orjson-3.11.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:ab49d4b2a6a1d415ddb9f37a21e02e0d5dbfe10b7870b21bf779fc21e9156157", size = 408695, upload-time = "2026-02-02T15:38:18.831Z" },
+    { url = "https://files.pythonhosted.org/packages/18/07/9dd2f0c0104f1a0295ffbe912bc8d63307a539b900dd9e2c48ef7810d971/orjson-3.11.7-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:390a1dce0c055ddf8adb6aa94a73b45a4a7d7177b5c584b8d1c1947f2ba60fb3", size = 144099, upload-time = "2026-02-02T15:38:20.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/66/857a8e4a3292e1f7b1b202883bcdeb43a91566cf59a93f97c53b44bd6801/orjson-3.11.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1eb80451a9c351a71dfaf5b7ccc13ad065405217726b59fdbeadbcc544f9d223", size = 134806, upload-time = "2026-02-02T15:38:22.186Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5b/6ebcf3defc1aab3a338ca777214966851e92efb1f30dc7fc8285216e6d1b/orjson-3.11.7-cp313-cp313-win32.whl", hash = "sha256:7477aa6a6ec6139c5cb1cc7b214643592169a5494d200397c7fc95d740d5fcf3", size = 127914, upload-time = "2026-02-02T15:38:23.511Z" },
+    { url = "https://files.pythonhosted.org/packages/00/04/c6f72daca5092e3117840a1b1e88dfc809cc1470cf0734890d0366b684a1/orjson-3.11.7-cp313-cp313-win_amd64.whl", hash = "sha256:b9f95dcdea9d4f805daa9ddf02617a89e484c6985fa03055459f90e87d7a0757", size = 124986, upload-time = "2026-02-02T15:38:24.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/ba/077a0f6f1085d6b806937246860fafbd5b17f3919c70ee3f3d8d9c713f38/orjson-3.11.7-cp313-cp313-win_arm64.whl", hash = "sha256:800988273a014a0541483dc81021247d7eacb0c845a9d1a34a422bc718f41539", size = 126045, upload-time = "2026-02-02T15:38:26.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/1e/745565dca749813db9a093c5ebc4bac1a9475c64d54b95654336ac3ed961/orjson-3.11.7-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:de0a37f21d0d364954ad5de1970491d7fbd0fb1ef7417d4d56a36dc01ba0c0a0", size = 228391, upload-time = "2026-02-02T15:38:27.757Z" },
+    { url = "https://files.pythonhosted.org/packages/46/19/e40f6225da4d3aa0c8dc6e5219c5e87c2063a560fe0d72a88deb59776794/orjson-3.11.7-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:c2428d358d85e8da9d37cba18b8c4047c55222007a84f97156a5b22028dfbfc0", size = 125188, upload-time = "2026-02-02T15:38:29.241Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7e/c4de2babef2c0817fd1f048fd176aa48c37bec8aef53d2fa932983032cce/orjson-3.11.7-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c4bc6c6ac52cdaa267552544c73e486fecbd710b7ac09bc024d5a78555a22f6", size = 128097, upload-time = "2026-02-02T15:38:30.618Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/74/233d360632bafd2197f217eee7fb9c9d0229eac0c18128aee5b35b0014fe/orjson-3.11.7-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd0d68edd7dfca1b2eca9361a44ac9f24b078de3481003159929a0573f21a6bf", size = 123364, upload-time = "2026-02-02T15:38:32.363Z" },
+    { url = "https://files.pythonhosted.org/packages/79/51/af79504981dd31efe20a9e360eb49c15f06df2b40e7f25a0a52d9ae888e8/orjson-3.11.7-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:623ad1b9548ef63886319c16fa317848e465a21513b31a6ad7b57443c3e0dcf5", size = 129076, upload-time = "2026-02-02T15:38:33.68Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e2/da898eb68b72304f8de05ca6715870d09d603ee98d30a27e8a9629abc64b/orjson-3.11.7-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6e776b998ac37c0396093d10290e60283f59cfe0fc3fccbd0ccc4bd04dd19892", size = 141705, upload-time = "2026-02-02T15:38:34.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/89/15364d92acb3d903b029e28d834edb8780c2b97404cbf7929aa6b9abdb24/orjson-3.11.7-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:652c6c3af76716f4a9c290371ba2e390ede06f6603edb277b481daf37f6f464e", size = 130855, upload-time = "2026-02-02T15:38:36.379Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8b/ecdad52d0b38d4b8f514be603e69ccd5eacf4e7241f972e37e79792212ec/orjson-3.11.7-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a56df3239294ea5964adf074c54bcc4f0ccd21636049a2cf3ca9cf03b5d03cf1", size = 133386, upload-time = "2026-02-02T15:38:37.704Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0e/45e1dcf10e17d0924b7c9162f87ec7b4ca79e28a0548acf6a71788d3e108/orjson-3.11.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bda117c4148e81f746655d5a3239ae9bd00cb7bc3ca178b5fc5a5997e9744183", size = 138295, upload-time = "2026-02-02T15:38:39.096Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d7/4d2e8b03561257af0450f2845b91fbd111d7e526ccdf737267108075e0ba/orjson-3.11.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:23d6c20517a97a9daf1d48b580fcdc6f0516c6f4b5038823426033690b4d2650", size = 408720, upload-time = "2026-02-02T15:38:40.634Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cf/d45343518282108b29c12a65892445fc51f9319dc3c552ceb51bb5905ed2/orjson-3.11.7-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:8ff206156006da5b847c9304b6308a01e8cdbc8cce824e2779a5ba71c3def141", size = 144152, upload-time = "2026-02-02T15:38:42.262Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3a/d6001f51a7275aacd342e77b735c71fa04125a3f93c36fee4526bc8c654e/orjson-3.11.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:962d046ee1765f74a1da723f4b33e3b228fe3a48bd307acce5021dfefe0e29b2", size = 134814, upload-time = "2026-02-02T15:38:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d3/f19b47ce16820cc2c480f7f1723e17f6d411b3a295c60c8ad3aa9ff1c96a/orjson-3.11.7-cp314-cp314-win32.whl", hash = "sha256:89e13dd3f89f1c38a9c9eba5fbf7cdc2d1feca82f5f290864b4b7a6aac704576", size = 127997, upload-time = "2026-02-02T15:38:45.06Z" },
+    { url = "https://files.pythonhosted.org/packages/12/df/172771902943af54bf661a8d102bdf2e7f932127968080632bda6054b62c/orjson-3.11.7-cp314-cp314-win_amd64.whl", hash = "sha256:845c3e0d8ded9c9271cd79596b9b552448b885b97110f628fb687aee2eed11c1", size = 124985, upload-time = "2026-02-02T15:38:46.388Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1c/f2a8d8a1b17514660a614ce5f7aac74b934e69f5abc2700cc7ced882a009/orjson-3.11.7-cp314-cp314-win_arm64.whl", hash = "sha256:4a2e9c5be347b937a2e0203866f12bba36082e89b402ddb9e927d5822e43088d", size = 126038, upload-time = "2026-02-02T15:38:47.703Z" },
 ]
 
 [[package]]
@@ -1780,6 +2107,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2018,6 +2364,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2040,12 +2398,54 @@ wheels = [
 ]
 
 [[package]]
+name = "pyobjc-core"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b6/d5612eb40be4fd5ef88c259339e6313f46ba67577a95d86c3470b951fce0/pyobjc_core-12.1.tar.gz", hash = "sha256:2bb3903f5387f72422145e1466b3ac3f7f0ef2e9960afa9bcd8961c5cbf8bd21", size = 1000532, upload-time = "2025-11-14T10:08:28.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/bf/3dbb1783388da54e650f8a6b88bde03c101d9ba93dfe8ab1b1873f1cd999/pyobjc_core-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:93418e79c1655f66b4352168f8c85c942707cb1d3ea13a1da3e6f6a143bacda7", size = 676748, upload-time = "2025-11-14T09:30:50.023Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/d2b290708e9da86d6e7a9a2a2022b91915cf2e712a5a82e306cb6ee99792/pyobjc_core-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c918ebca280925e7fcb14c5c43ce12dcb9574a33cccb889be7c8c17f3bcce8b6", size = 671263, upload-time = "2025-11-14T09:31:35.231Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5a/6b15e499de73050f4a2c88fff664ae154307d25dc04da8fb38998a428358/pyobjc_core-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:818bcc6723561f207e5b5453efe9703f34bc8781d11ce9b8be286bb415eb4962", size = 678335, upload-time = "2025-11-14T09:32:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d2/29e5e536adc07bc3d33dd09f3f7cf844bf7b4981820dc2a91dd810f3c782/pyobjc_core-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:01c0cf500596f03e21c23aef9b5f326b9fb1f8f118cf0d8b66749b6cf4cbb37a", size = 677370, upload-time = "2025-11-14T09:33:05.273Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/f0/4b4ed8924cd04e425f2a07269943018d43949afad1c348c3ed4d9d032787/pyobjc_core-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:177aaca84bb369a483e4961186704f64b2697708046745f8167e818d968c88fc", size = 719586, upload-time = "2025-11-14T09:33:53.302Z" },
+    { url = "https://files.pythonhosted.org/packages/25/98/9f4ed07162de69603144ff480be35cd021808faa7f730d082b92f7ebf2b5/pyobjc_core-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:844515f5d86395b979d02152576e7dee9cc679acc0b32dc626ef5bda315eaa43", size = 670164, upload-time = "2025-11-14T09:34:37.458Z" },
+    { url = "https://files.pythonhosted.org/packages/62/50/dc076965c96c7f0de25c0a32b7f8aa98133ed244deaeeacfc758783f1f30/pyobjc_core-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:453b191df1a4b80e756445b935491b974714456ae2cbae816840bd96f86db882", size = 712204, upload-time = "2025-11-14T09:35:24.148Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/aa/2b2d7ec3ac4b112a605e9bd5c5e5e4fd31d60a8a4b610ab19cc4838aa92a/pyobjc_framework_cocoa-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9b880d3bdcd102809d704b6d8e14e31611443aa892d9f60e8491e457182fdd48", size = 383825, upload-time = "2025-11-14T09:40:28.354Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/07/5760735c0fffc65107e648eaf7e0991f46da442ac4493501be5380e6d9d4/pyobjc_framework_cocoa-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f52228bcf38da64b77328787967d464e28b981492b33a7675585141e1b0a01e6", size = 383812, upload-time = "2025-11-14T09:40:53.169Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/ee4f27ec3920d5c6fc63c63e797c5b2cc4e20fe439217085d01ea5b63856/pyobjc_framework_cocoa-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:547c182837214b7ec4796dac5aee3aa25abc665757b75d7f44f83c994bcb0858", size = 384590, upload-time = "2025-11-14T09:41:17.336Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/31/0c2e734165abb46215797bd830c4bdcb780b699854b15f2b6240515edcc6/pyobjc_framework_cocoa-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5a3dcd491cacc2f5a197142b3c556d8aafa3963011110102a093349017705118", size = 384689, upload-time = "2025-11-14T09:41:41.478Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3b/b9f61be7b9f9b4e0a6db18b3c35c4c4d589f2d04e963e2174d38c6555a92/pyobjc_framework_cocoa-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:914b74328c22d8ca261d78c23ef2befc29776e0b85555973927b338c5734ca44", size = 388843, upload-time = "2025-11-14T09:42:05.719Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/f777cc9e775fc7dae77b569254570fe46eb842516b3e4fe383ab49eab598/pyobjc_framework_cocoa-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:03342a60fc0015bcdf9b93ac0b4f457d3938e9ef761b28df9564c91a14f0129a", size = 384932, upload-time = "2025-11-14T09:42:29.771Z" },
+    { url = "https://files.pythonhosted.org/packages/58/27/b457b7b37089cad692c8aada90119162dfb4c4a16f513b79a8b2b022b33b/pyobjc_framework_cocoa-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6ba1dc1bfa4da42d04e93d2363491275fb2e2be5c20790e561c8a9e09b8cf2cc", size = 388970, upload-time = "2025-11-14T09:42:53.964Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
 ]
 
 [[package]]
@@ -2064,19 +2464,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
-]
-
-[[package]]
-name = "pytest-vcr"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-    { name = "vcrpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/60/104c619483c1a42775d3f8b27293f1ecfc0728014874d065e68cb9702d49/pytest-vcr-1.0.2.tar.gz", hash = "sha256:23ee51b75abbcc43d926272773aae4f39f93aceb75ed56852d0bf618f92e1896", size = 3810, upload-time = "2019-04-26T19:04:00.806Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/d3/ff520d11e6ee400602711d1ece8168dcfc5b6d8146fb7db4244a6ad6a9c3/pytest_vcr-1.0.2-py2.py3-none-any.whl", hash = "sha256:2f316e0539399bea0296e8b8401145c62b6f85e9066af7e57b6151481b0d6d9c", size = 4137, upload-time = "2019-04-26T19:03:57.034Z" },
 ]
 
 [[package]]
@@ -2262,19 +2649,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests-oauthlib"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "oauthlib" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
-]
-
-[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2310,6 +2684,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
     { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
     { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+]
+
+[[package]]
+name = "screeninfo"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cython", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/bb/e69e5e628d43f118e0af4fc063c20058faa8635c95a1296764acc8167e27/screeninfo-0.8.1.tar.gz", hash = "sha256:9983076bcc7e34402a1a9e4d7dabf3729411fd2abb3f3b4be7eba73519cd2ed1", size = 10666, upload-time = "2022-09-09T11:35:23.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/bf/c5205d480307bef660e56544b9e3d7ff687da776abb30c9cb3f330887570/screeninfo-0.8.1-py3-none-any.whl", hash = "sha256:e97d6b173856edcfa3bd282f81deb528188aff14b11ec3e195584e7641be733c", size = 12907, upload-time = "2022-09-09T11:35:21.351Z" },
 ]
 
 [[package]]
@@ -2407,6 +2794,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
 name = "traitlets"
 version = "5.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2470,25 +2869,32 @@ wheels = [
 ]
 
 [[package]]
+name = "ua-parser"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ua-parser-builtins" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/0e/ed98be735bc89d5040e0c60f5620d0b8c04e9e7da99ed1459e8050e90a77/ua_parser-1.0.1.tar.gz", hash = "sha256:f9d92bf19d4329019cef91707aecc23c6d65143ad7e29a233f0580fb0d15547d", size = 728106, upload-time = "2025-02-01T14:13:32.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/37/be6dfbfa45719aa82c008fb4772cfe5c46db765a2ca4b6f524a1fdfee4d7/ua_parser-1.0.1-py3-none-any.whl", hash = "sha256:b059f2cb0935addea7e551251cbbf42e9a8872f86134163bc1a4f79e0945ffea", size = 31410, upload-time = "2025-02-01T14:13:28.458Z" },
+]
+
+[[package]]
+name = "ua-parser-builtins"
+version = "202603"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/6f/73a4d37deefb159556d39d654b5bad67b6874d1ad0b20b96fb5a04de3949/ua_parser_builtins-202603-py3-none-any.whl", hash = "sha256:67478397a68fac1a98fd0a31c416ea7c65a719141fc151d0211316f2cd337cc9", size = 89573, upload-time = "2026-03-01T20:50:02.491Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "vcrpy"
-version = "8.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/07/bcfd5ebd7cb308026ab78a353e091bd699593358be49197d39d004e5ad83/vcrpy-8.1.1.tar.gz", hash = "sha256:58e3053e33b423f3594031cb758c3f4d1df931307f1e67928e30cf352df7709f", size = 85770, upload-time = "2026-01-04T19:22:03.886Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/d7/f79b05a5d728f8786876a7d75dfb0c5cae27e428081b2d60152fb52f155f/vcrpy-8.1.1-py3-none-any.whl", hash = "sha256:2d16f31ad56493efb6165182dd99767207031b0da3f68b18f975545ede8ac4b9", size = 42445, upload-time = "2026-01-04T19:22:02.532Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR revives garth by replacing the broken HTTP transport with Camoufox browser automation. Garmin made multiple changes that broke all Python access: the SSO login endpoint (`/mobile/api/login`) was disabled and returns 400, the OAuth token endpoint (`/oauth-service/oauth/preauthorized`) was disabled and returns 401, and aggressive Cloudflare bot detection was deployed that blocks every Python HTTP client including `requests`, `httpx`, and `curl_cffi`, even with Chrome TLS impersonation. Extracting cookies from a browser and replaying them in Python also fails. There is no HTTP-level fix.

The only working method is `page.evaluate(fetch(...))` inside a real browser. This PR implements that.

## Why

garth was deprecated on March 28, 2026 because Garmin's changes made it unfixable at the HTTP level. But garth is not just a library. It's the foundation of an ecosystem.

**python-garminconnect** with 1.7K stars depends on garth for auth. The **Home Assistant Garmin integration** with 452 stars depends on python-garminconnect. **GarminDB** with 3K stars, **garminexport** with 564 stars, **garmin-connect-export** with 486 stars are all broken. Dozens of MCP servers, fitness tools, and personal health projects are all dead.

The maintainers of these projects didn't choose to break. Garmin forced it. This PR gives them a path back.

## What changed

### Source files (7 files)

| File | Change |
|------|--------|
| `sso.py` | Rewritten. Browser-based SSO login via Camoufox. Handles MFA in-browser. Session cookies saved to `~/.garth/` with roughly 1 year lifetime. |
| `http.py` | Rewritten. `Client.request()` routes through `page.evaluate(fetch(...))`. Binary download via FileReader/blob. Upload via FormData. |
| `data/_base.py` | `Data.list()` runs sequentially instead of `ThreadPoolExecutor` because Playwright cannot be called from multiple threads. |
| `exc.py` | `GarthHTTPError.error` changed from `requests.HTTPError` to base `Exception`. |
| `telemetry.py` | Removed `requests.Session`/`Response` dependency. Sanitization utilities preserved. |
| `__init__.py` | Removed deprecation warning. Added `close` export for browser cleanup. |
| `pyproject.toml` | Dependencies changed from `requests` and `requests-oauthlib` to `camoufox` and `playwright`. Status changed from Inactive to Beta. |

### Test files (5 files)

| File | Change |
|------|--------|
| `conftest.py` | Cassette replay via YAML loading instead of VCR HTTP interception. Same cassette data, different replay mechanism. |
| `test_sso.py` | Rewritten for browser login. Covers exchange, placeholder tokens, sentinel detection, and close cleanup. |
| `test_http.py` | Adapted. Token persistence tests preserved. Added browser token warning, proxy/ssl_verify warnings, multi-file upload rejection, and download via mock page. |
| `test_telemetry.py` | Simplified. Sanitization tests preserved. Removed requests-dependent session and response hook tests. |
| `test_cli.py` | Mocks `sso.login()` instead of VCR replay. |

### Not changed

All data models in the `data/` directory are untouched. All stats classes in the `stats/` directory are untouched. `auth_tokens.py`, `utils.py`, `cli.py`, and the `users/` module are all untouched. All cassette YAML files are preserved as test data.

## How it works

```
User code (garth.connectapi, garth.login, etc.)
    │
    ▼
garth.http.Client.request()
    │
    ▼
page.evaluate(fetch(...))  ← runs inside Camoufox browser
    │
    ▼
Garmin Connect API  ← sees a real browser, Cloudflare allows it
```

First, `garth.login(email, password)` launches a headless Camoufox browser, navigates to Garmin SSO, fills the login form, and handles MFA if needed. Then saves session cookies.

After that, `Client.request()` routes all API calls through `page.evaluate(fetch(...))`, which is JavaScript `fetch()` running inside the browser context.

Session cookies persist to `~/.garth/browser_session.json` for roughly 1 year. Subsequent runs restore cookies so no login or MFA is needed.

## What I tested before submitting

I tested every approach before landing on browser automation:

| Approach | Result |
|----------|--------|
| `requests` with cookies | 403 Forbidden |
| `curl_cffi` with Chrome TLS impersonation | 403 Forbidden |
| `httpx` with extracted browser cookies | 403 Forbidden |
| garth's SSO login (`/mobile/api/login`) | 400 Bad Request, endpoint disabled |
| OAuth1 preauthorized endpoint | 401 Unauthorized, endpoint disabled |
| Browser cookies replayed in Python | 403 Forbidden |
| **`page.evaluate(fetch(...))` in Camoufox** | **200 OK** |

## Test results

137 unit tests passing, down from 163 because tests for dead HTTP code were removed while all data model tests were kept.

72 out of 72 live integration tests passing against the real Garmin API, covering 24 connectapi endpoints, 14 data model `.get()` calls, 13 data model `.list()` calls, 12 stats class `.list()` calls, binary FIT file download, and token persistence through dump, load, dumps, and loads.

## Known limitations

| Limitation | Details |
|------------|---------|
| **Not thread-safe** | Playwright uses greenlets bound to a single thread. `page.evaluate()` cannot be called from multiple threads. `Data.list()` was changed to run sequentially instead of using `ThreadPoolExecutor`. |
| **Single session** | Module-level browser state means one active Garmin session at a time. This matches garth's existing singleton pattern with `garth.client`. Multi-account requires separate processes. |
| **Memory** | Camoufox uses roughly 200 to 300 MB RAM for the headless browser. |
| **Disk** | Camoufox and Playwright install roughly 500 MB of browser binaries. |
| **Startup** | First login takes 10 to 15 seconds for browser launch and SSO. Subsequent runs with cached cookies take 3 to 5 seconds. |
| **Placeholder tokens** | `login()` returns placeholder OAuth tokens with a sentinel value of `"browser_session"`. The browser session handles real auth via cookies. Code that inspects token contents will see fake values. `load()` and `loads()` detect these and warn users to call `login()`. |
| **`return_on_mfa` not supported** | Raises `NotImplementedError`. MFA is handled interactively in the browser via the `prompt_mfa` callback. |
| **`proxies` and `ssl_verify` not supported** | Accepted for API compatibility but emit warnings. Browser transport handles networking differently. |

## Intent

This is not a small patch. It's a fundamental transport change forced by Garmin's decisions to disable auth endpoints and deploy aggressive bot detection. The goal is to:

1. **Unblock the ecosystem** so every downstream project can work again by updating garth
2. **Preserve the API surface** so `garth.login()`, `garth.connectapi()`, `garth.download()`, data models, and stats classes all work exactly as before
3. **Preserve test data** so all cassette YAML files with real API responses are kept as test fixtures
4. **Be honest about tradeoffs** because browser transport is heavier than HTTP, single-threaded, and requires roughly 500 MB of browser binaries, but it works, and the HTTP path does not

I'm not asking garth to endorse browser automation as an ideal architecture. I'm saying the community needs garth to work, and this is the only way to make it work today, unless someone in the community finds a different approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser-based authentication and interactive MFA with a new close() for session cleanup

* **Improvements**
  * Project status updated to Beta
  * HTTP operations now routed through a browser-driven transport
  * Sequential request execution (concurrency defaults to single-worker)
  * Telemetry no longer hooks HTTP sessions; proxy/ssl options now warn

* **Chores**
  * Updated runtime/testing dependencies (added camoufox, playwright, pyyaml; removed requests-related packages)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->